### PR TITLE
fix: pipename length macos

### DIFF
--- a/EasyDotnet.Tool/EasyDotnet.csproj
+++ b/EasyDotnet.Tool/EasyDotnet.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>1.0.8</Version>
+    <Version>1.0.9</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <Nullable>enable</Nullable>

--- a/EasyDotnet.Tool/Program.cs
+++ b/EasyDotnet.Tool/Program.cs
@@ -62,7 +62,7 @@ class Program
   {
     var pipeName = "EasyDotnet_" + Regex.Replace(Convert.ToBase64String(Guid.NewGuid().ToByteArray()), "[/+=]", "");
     var maxNameLength = MaxPipeNameLength - Path.GetTempPath().Length;
-    return pipeName[..Math.Min(pipeName.Length, MaxPipeNameLength)];
+    return pipeName[..Math.Min(pipeName.Length, maxNameLength)];
   }
 
   private static async Task RespondToRpcRequestsAsync(Stream stream, int clientId)

--- a/EasyDotnet.Tool/Program.cs
+++ b/EasyDotnet.Tool/Program.cs
@@ -11,7 +11,7 @@ using EasyDotnet.Utils;
 
 class Program
 {
-  private static readonly string PipeName = "EasyDotnet_" + Regex.Replace(Convert.ToBase64String(Guid.NewGuid().ToByteArray()), "[/+=]", "");
+  private const int MaxPipeNameLength = 103;
 
   public static async Task<int> Main(string[] args)
   {
@@ -46,6 +46,8 @@ class Program
 
   private static async Task StartServerAsync()
   {
+    var PipeName = GeneratePipeName();
+
     var clientId = 0;
     while (true)
     {
@@ -54,6 +56,13 @@ class Program
       await stream.WaitForConnectionAsync();
       _ = RespondToRpcRequestsAsync(stream, ++clientId);
     }
+  }
+
+  private static string GeneratePipeName()
+  {
+    var pipeName = "EasyDotnet_" + Regex.Replace(Convert.ToBase64String(Guid.NewGuid().ToByteArray()), "[/+=]", "");
+    var maxNameLength = MaxPipeNameLength - Path.GetTempPath().Length;
+    return pipeName[..Math.Min(pipeName.Length, MaxPipeNameLength)];
   }
 
   private static async Task RespondToRpcRequestsAsync(Stream stream, int clientId)

--- a/EasyDotnet.Tool/Services/MsBuildHostManagerService.cs
+++ b/EasyDotnet.Tool/Services/MsBuildHostManagerService.cs
@@ -27,9 +27,7 @@ public interface IMsBuildHostManager
 
 public class MsBuildHostManager : IMsBuildHostManager, IDisposable
 {
-  // on macOS the temp path is long. Total length of pipename must be no longer that 104 characters
-  // the path /{tmpPath}/CoreFxPipe is exactly 60 characters. MaxPipeNameLength must be 44
-  private const int MaxPipeNameLength = 44;
+  private const int MaxPipeNameLength = 103;
   private readonly string _sdk_Pipe = GeneratePipeName(BuildClientType.Sdk);
   private readonly string _framework_Pipe = GeneratePipeName(BuildClientType.Framework);
 
@@ -54,7 +52,8 @@ public class MsBuildHostManager : IMsBuildHostManager, IDisposable
     var pipePrefix = "EasyDotnet_MSBuild_";
     var uid = Regex.Replace(Convert.ToBase64String(Guid.NewGuid().ToByteArray()), "[/+=]", "");
     var name = $"{pipePrefix}{type}_{uid}";
-    return name[..Math.Min(name.Length, MaxPipeNameLength)];
+    var maxNameLength = MaxPipeNameLength - Path.GetTempPath().Length;
+    return name[..Math.Min(name.Length, maxNameLength)];
   }
 
   public void StopAll()


### PR DESCRIPTION
Ok, I asked a friend to check and didn't work. So...
Instead we should check max length of PipeName by taking the macOS max named pipe length (104, but use 103 for extra safety) and subtract the Path.GetTempPath().Length. 
Should have done this in the first place. 
