### PR TITLE
Fixes Pipename to long on macOS

### DIFF
--- a/EasyDotnet.Tool/EasyDotnet.csproj
+++ b/EasyDotnet.Tool/EasyDotnet.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>1.0.9</Version>
+    <Version>1.0.10</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <Nullable>enable</Nullable>

--- a/EasyDotnet.Tool/Program.cs
+++ b/EasyDotnet.Tool/Program.cs
@@ -11,7 +11,7 @@ using EasyDotnet.Utils;
 
 class Program
 {
-  private const int MaxPipeNameLength = 103;
+  private const int MaxPipeNameLength = 104;
 
   public static async Task<int> Main(string[] args)
   {
@@ -60,8 +60,9 @@ class Program
 
   private static string GeneratePipeName()
   {
+    var pipePrefix = "CoreFxPipe_";
     var pipeName = "EasyDotnet_" + Regex.Replace(Convert.ToBase64String(Guid.NewGuid().ToByteArray()), "[/+=]", "");
-    var maxNameLength = MaxPipeNameLength - Path.GetTempPath().Length;
+    var maxNameLength = MaxPipeNameLength - Path.GetTempPath().Length - pipePrefix.Length - 1;
     return pipeName[..Math.Min(pipeName.Length, maxNameLength)];
   }
 

--- a/EasyDotnet.Tool/Services/MsBuildHostManagerService.cs
+++ b/EasyDotnet.Tool/Services/MsBuildHostManagerService.cs
@@ -27,7 +27,7 @@ public interface IMsBuildHostManager
 
 public class MsBuildHostManager : IMsBuildHostManager, IDisposable
 {
-  private const int MaxPipeNameLength = 103;
+  private const int MaxPipeNameLength = 104;
   private readonly string _sdk_Pipe = GeneratePipeName(BuildClientType.Sdk);
   private readonly string _framework_Pipe = GeneratePipeName(BuildClientType.Framework);
 
@@ -49,10 +49,11 @@ public class MsBuildHostManager : IMsBuildHostManager, IDisposable
 
   private static string GeneratePipeName(BuildClientType type)
   {
-    var pipePrefix = "EasyDotnet_MSBuild_";
+    var pipePrefix = "CoreFxPipe_";
+    var pipeName = "EasyDotnet_MSBuild_";
     var uid = Regex.Replace(Convert.ToBase64String(Guid.NewGuid().ToByteArray()), "[/+=]", "");
-    var name = $"{pipePrefix}{type}_{uid}";
-    var maxNameLength = MaxPipeNameLength - Path.GetTempPath().Length;
+    var name = $"{pipeName}{type}_{uid}";
+    var maxNameLength = MaxPipeNameLength - Path.GetTempPath().Length - pipePrefix.Length - 1;
     return name[..Math.Min(name.Length, maxNameLength)];
   }
 


### PR DESCRIPTION
Fix #52. 
So finally... Tested on three different mac's.