### PR TITLE
feat: resolve applicationhost.config

### DIFF
--- a/EasyDotnet.Tool/Controllers/Initialize/InitializeRequest.cs
+++ b/EasyDotnet.Tool/Controllers/Initialize/InitializeRequest.cs
@@ -3,7 +3,7 @@ namespace EasyDotnet.Controllers.Initialize;
 
 public sealed record InitializeRequest(ClientInfo ClientInfo, ProjectInfo ProjectInfo, Options? Options);
 
-public sealed record ProjectInfo(string RootDir);
+public sealed record ProjectInfo(string RootDir, string? SolutionFile);
 
 public sealed record Options(bool UseVisualStudio = false);
 

--- a/EasyDotnet.Tool/EasyDotnet.csproj
+++ b/EasyDotnet.Tool/EasyDotnet.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>1.0.22</Version>
+    <Version>1.0.23</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
When running IISExpress projects in .net framework the `applicationhost.config` file is needed