### PR TITLE
feat: add roslyn/get-workspace-diagnostics endpoint

### DIFF
--- a/EasyDotnet.IntegrationTests/Roslyn/DiagnosticsTests.cs
+++ b/EasyDotnet.IntegrationTests/Roslyn/DiagnosticsTests.cs
@@ -1,0 +1,219 @@
+using EasyDotnet.Controllers.Roslyn;
+using EasyDotnet.IntegrationTests.Utils;
+
+namespace EasyDotnet.IntegrationTests.Roslyn;
+
+public class DiagnosticsTests
+{
+  private async Task<List<DiagnosticMessage>> GetDiagnosticsAsync(
+    string projectPath,
+    bool includeWarnings = false)
+  {
+    using var server = await RpcTestServerInstantiator.GetInitializedStreamServer();
+
+    var request = new { projectPath, includeWarnings };
+
+    var diagnosticsStream = await server.InvokeWithParameterObjectAsync<IAsyncEnumerable<DiagnosticMessage>>(
+      "roslyn/get-workspace-diagnostics",
+      request
+    );
+
+    var diagnostics = new List<DiagnosticMessage>();
+    await foreach (var diagnostic in diagnosticsStream)
+    {
+      diagnostics.Add(diagnostic);
+    }
+    return diagnostics;
+  }
+
+  [Fact]
+  public async Task GetDiagnostics_WithErrors_ReturnsErrorDiagnostics()
+  {
+    using var tempProject = new TempDotNetProjectWithError();
+
+    var diagnostics = await GetDiagnosticsAsync(tempProject.CsprojPath);
+
+    Assert.NotEmpty(diagnostics);
+
+    var errorDiagnostic = diagnostics.FirstOrDefault(d => d.Code == "CS0103");
+    Assert.NotNull(errorDiagnostic);
+    Assert.Equal(1, errorDiagnostic.Severity);
+    Assert.Contains("UndefinedVariable", errorDiagnostic.Message);
+    Assert.Equal("roslyn", errorDiagnostic.Source);
+    Assert.NotNull(errorDiagnostic.FilePath);
+    Assert.EndsWith("ProgramWithError.cs", errorDiagnostic.FilePath);
+  }
+
+  [Fact]
+  public async Task GetDiagnostics_WithWarnings_ReturnsWarningsWhenRequested()
+  {
+    using var tempProject = new TempDotNetProjectWithWarning();
+
+    var diagnosticsWithoutWarnings = await GetDiagnosticsAsync(tempProject.CsprojPath);
+    var warningDiagnostic = diagnosticsWithoutWarnings.FirstOrDefault(d => d.Code == "CS0219");
+    Assert.Null(warningDiagnostic);
+
+    var diagnosticsWithWarnings = await GetDiagnosticsAsync(tempProject.CsprojPath, includeWarnings: true);
+    warningDiagnostic = diagnosticsWithWarnings.FirstOrDefault(d => d.Code == "CS0219");
+    Assert.NotNull(warningDiagnostic);
+    Assert.Equal(2, warningDiagnostic.Severity);
+    Assert.Contains("unusedVariable", warningDiagnostic.Message);
+  }
+
+  [Fact]
+  public async Task GetDiagnostics_ValidProject_ReturnsCorrectPositions()
+  {
+    using var tempProject = new TempDotNetProjectWithError();
+
+    var diagnostics = await GetDiagnosticsAsync(tempProject.CsprojPath, includeWarnings: true);
+    var errorDiagnostic = diagnostics.FirstOrDefault(d => d.Code == "CS0103");
+
+    Assert.NotNull(errorDiagnostic);
+    Assert.NotNull(errorDiagnostic.Range);
+
+    Assert.True(errorDiagnostic.Range.Start.Line >= 0);
+    Assert.True(errorDiagnostic.Range.Start.Character >= 0);
+    Assert.True(errorDiagnostic.Range.End.Line >= 0);
+    Assert.True(errorDiagnostic.Range.End.Character >= 0);
+
+    Assert.Equal(6, errorDiagnostic.Range.Start.Line);
+  }
+
+  [Fact]
+  public async Task GetDiagnostics_WithSolutionFile_ReturnsAllProjectDiagnostics()
+  {
+    using var tempSolution = new TempDotNetSolution();
+
+    var diagnostics = await GetDiagnosticsAsync(tempSolution.SolutionPath);
+    Assert.NotEmpty(diagnostics);
+
+    var project1Errors = diagnostics.Where(d => d.FilePath.Contains("Project1")).ToList();
+    var project2Errors = diagnostics.Where(d => d.FilePath.Contains("Project2")).ToList();
+
+    Assert.NotEmpty(project1Errors);
+    Assert.NotEmpty(project2Errors);
+  }
+
+  private class TempDotNetProjectWithError : TempDotNetProject
+  {
+    public TempDotNetProjectWithError() : base("TestProjectWithError")
+    {
+      var programWithErrorCode = @"using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine(UndefinedVariable);
+    }
+}";
+      File.WriteAllText(Path.Combine(ProjectDirectory, "ProgramWithError.cs"), programWithErrorCode);
+      File.Delete(ProgramCsPath);
+    }
+  }
+
+  private class TempDotNetProjectWithWarning : TempDotNetProject
+  {
+    public TempDotNetProjectWithWarning() : base("TestProjectWithWarning")
+    {
+      var programWithWarningCode = @"using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        int unusedVariable = 42;
+        Console.WriteLine(""Hello, World!"");
+    }
+}";
+      File.WriteAllText(Path.Combine(ProjectDirectory, "ProgramWithWarning.cs"), programWithWarningCode);
+      File.Delete(ProgramCsPath);
+    }
+  }
+
+  private class TempDotNetSolution : IDisposable
+  {
+    public string SolutionDirectory { get; }
+    public string SolutionPath { get; }
+    private readonly TempDotNetProject _project1;
+    private readonly TempDotNetProject _project2;
+
+    public TempDotNetSolution()
+    {
+      SolutionDirectory = Path.Combine(Path.GetTempPath(), $"TestSolution_{Guid.NewGuid()}");
+      Directory.CreateDirectory(SolutionDirectory);
+      SolutionPath = Path.Combine(SolutionDirectory, "TestSolution.sln");
+
+      _project1 = new TempDotNetProject("Project1");
+      _project2 = new TempDotNetProject("Project2");
+
+      var project1ErrorCode = @"using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Error1);
+    }
+}";
+      File.WriteAllText(Path.Combine(_project1.ProjectDirectory, "ProgramWithError.cs"), project1ErrorCode);
+      File.Delete(_project1.ProgramCsPath);
+
+      var project2ErrorCode = @"using System;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        Console.WriteLine(Error2);
+    }
+}";
+      File.WriteAllText(Path.Combine(_project2.ProjectDirectory, "ProgramWithError.cs"), project2ErrorCode);
+      File.Delete(_project2.ProgramCsPath);
+
+      CreateSolutionFile();
+    }
+
+    private void CreateSolutionFile()
+    {
+      var solutionContent = $@"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project(""{{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}}"") = ""Project1"", ""{_project1.CsprojPath}"", ""{{11111111-1111-1111-1111-111111111111}}""
+EndProject
+Project(""{{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}}"") = ""Project2"", ""{_project2.CsprojPath}"", ""{{22222222-2222-2222-2222-222222222222}}""
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{{11111111-1111-1111-1111-111111111111}}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{{11111111-1111-1111-1111-111111111111}}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{{11111111-1111-1111-1111-111111111111}}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{{11111111-1111-1111-1111-111111111111}}.Release|Any CPU.Build.0 = Release|Any CPU
+		{{22222222-2222-2222-2222-222222222222}}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{{22222222-2222-2222-2222-222222222222}}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{{22222222-2222-2222-2222-222222222222}}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{{22222222-2222-2222-2222-222222222222}}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal
+";
+      File.WriteAllText(SolutionPath, solutionContent);
+    }
+
+    public void Dispose()
+    {
+      _project1?.Dispose();
+      _project2?.Dispose();
+
+      if (Directory.Exists(SolutionDirectory))
+      {
+        Directory.Delete(SolutionDirectory, recursive: true);
+      }
+    }
+  }
+}

--- a/EasyDotnet.Tool/Controllers/Roslyn/DiagnosticMessage.cs
+++ b/EasyDotnet.Tool/Controllers/Roslyn/DiagnosticMessage.cs
@@ -1,0 +1,13 @@
+namespace EasyDotnet.Controllers.Roslyn;
+
+public sealed record DiagnosticPosition(int Line, int Character);
+public sealed record DiagnosticRange(DiagnosticPosition Start, DiagnosticPosition End);
+public sealed record DiagnosticMessage(
+    string FilePath,
+    DiagnosticRange Range,
+    int Severity,
+    string Message,
+    string Code,
+    string Source = "roslyn",
+    string? Category = null
+);

--- a/EasyDotnet.Tool/Controllers/Roslyn/RoslynController.cs
+++ b/EasyDotnet.Tool/Controllers/Roslyn/RoslynController.cs
@@ -23,4 +23,10 @@ public class RoslynController(RoslynService roslynService) : BaseController
     var res = await roslynService.AnalyzeAsync(sourceFilePath, lineNumber);
     return res.Select(x => new VariableResultResponse(x.Identifier, x.LineStart, x.LineEnd, x.ColumnStart, x.ColumnEnd)).AsAsyncEnumerable();
   }
+
+  [JsonRpcMethod("roslyn/get-workspace-diagnostics")]
+  public IAsyncEnumerable<DiagnosticMessage> GetDiagnostics(string projectPath, bool includeWarnings = false)
+  {
+    return roslynService.GetWorkspaceDiagnosticsAsync(projectPath, includeWarnings);
+  }
 }

--- a/EasyDotnet.Tool/EasyDotnet.csproj
+++ b/EasyDotnet.Tool/EasyDotnet.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>1.0.28</Version>
+    <Version>1.0.29</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Add endpoint to get compiler diagnostics from solution and project files.
I built roslyn-diagnostics for this usecase but it is way more performant using the server :) 
Supports .sln, .csproj, and .fsproj files with vim.diagnostic compatible format.

## Known limitation
Roslyn semantic analysis may not detect all errors when syntax errors are present early on in the same file. This is consistent with LSP server behavior and is a known Roslyn limitation.

