### PR TITLE
feat: Standard output for test execution result

### DIFF
--- a/EasyDotnet.Tool/EasyDotnet.csproj
+++ b/EasyDotnet.Tool/EasyDotnet.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <Nullable>enable</Nullable>

--- a/EasyDotnet.Tool/Extensions/TestNodeExtensions.cs
+++ b/EasyDotnet.Tool/Extensions/TestNodeExtensions.cs
@@ -28,6 +28,7 @@ public static class TestNodeExtensions
     Outcome = test.Node.ExecutionState,
     Duration = (long?)test.Node.Duration,
     ErrorMessage = test.Node.Message,
-    StackTrace = (test.Node.StackTrace?.Split(Environment.NewLine) ?? []).AsAsyncEnumerable()
+    StackTrace = (test.Node.StackTrace?.Split(Environment.NewLine) ?? []).AsAsyncEnumerable(),
+    StdOut = test.Node.StandardOutput
   };
 }

--- a/EasyDotnet.Tool/Extensions/TestNodeExtensions.cs
+++ b/EasyDotnet.Tool/Extensions/TestNodeExtensions.cs
@@ -29,6 +29,6 @@ public static class TestNodeExtensions
     Duration = (long?)test.Node.Duration,
     ErrorMessage = test.Node.Message,
     StackTrace = (test.Node.StackTrace?.Split(Environment.NewLine) ?? []).AsAsyncEnumerable(),
-    StdOut = test.Node.StandardOutput
+    StdOut = (test.Node.StandardOutput?.Split(Environment.NewLine) ?? []).AsAsyncEnumerable()
   };
 }

--- a/EasyDotnet.Tool/MTP/RPC/Models/TestNodeUpdate.cs
+++ b/EasyDotnet.Tool/MTP/RPC/Models/TestNodeUpdate.cs
@@ -49,5 +49,8 @@ public sealed record TestNode
   string NodeType,
 
   [property: JsonProperty("execution-state")]
-  string ExecutionState
+  string ExecutionState,
+
+  [property: JsonProperty("standardOutput")]
+  string? StandardOutput
 );

--- a/EasyDotnet.Tool/Types/TestRunResult.cs
+++ b/EasyDotnet.Tool/Types/TestRunResult.cs
@@ -9,4 +9,5 @@ public sealed record TestRunResult
   public required long? Duration { get; init; }
   public required IAsyncEnumerable<string> StackTrace { get; init; }
   public required string? ErrorMessage { get; init; }
+  public required string? StdOut { get; init; }
 }

--- a/EasyDotnet.Tool/Types/TestRunResult.cs
+++ b/EasyDotnet.Tool/Types/TestRunResult.cs
@@ -9,5 +9,5 @@ public sealed record TestRunResult
   public required long? Duration { get; init; }
   public required IAsyncEnumerable<string> StackTrace { get; init; }
   public required string? ErrorMessage { get; init; }
-  public required string? StdOut { get; init; }
+  public required IAsyncEnumerable<string> StdOut { get; init; }
 }

--- a/EasyDotnet.Tool/VSTest/TestCaseExtensions.cs
+++ b/EasyDotnet.Tool/VSTest/TestCaseExtensions.cs
@@ -44,6 +44,6 @@ public static class TestCaseExtensions
     _ => "",
   };
 
-  private static string? GetStandardOutput(this TestResult testResult) 
+  private static string? GetStandardOutput(this TestResult testResult)
     => testResult.Messages.FirstOrDefault(message => message.Category == TestResultMessage.StandardOutCategory)?.Text;
 }

--- a/EasyDotnet.Tool/VSTest/TestCaseExtensions.cs
+++ b/EasyDotnet.Tool/VSTest/TestCaseExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using EasyDotnet.Types;
 
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
@@ -29,7 +30,8 @@ public static class TestCaseExtensions
     StackTrace = (x.ErrorStackTrace?.Split(Environment.NewLine) ?? []).AsAsyncEnumerable(),
     ErrorMessage = x.ErrorMessage,
     Id = x.TestCase.Id.ToString(),
-    Outcome = GetTestOutcome(x.Outcome)
+    Outcome = GetTestOutcome(x.Outcome),
+    StdOut = x.Messages.FirstOrDefault(message => message.Category == TestResultMessage.StandardOutCategory)?.Text
   };
 
   public static string GetTestOutcome(TestOutcome outcome) => outcome switch

--- a/EasyDotnet.Tool/VSTest/TestCaseExtensions.cs
+++ b/EasyDotnet.Tool/VSTest/TestCaseExtensions.cs
@@ -31,7 +31,7 @@ public static class TestCaseExtensions
     ErrorMessage = x.ErrorMessage,
     Id = x.TestCase.Id.ToString(),
     Outcome = GetTestOutcome(x.Outcome),
-    StdOut = x.Messages.FirstOrDefault(message => message.Category == TestResultMessage.StandardOutCategory)?.Text
+    StdOut = (x.GetStandardOutput()?.Split(Environment.NewLine) ?? []).AsAsyncEnumerable()
   };
 
   public static string GetTestOutcome(TestOutcome outcome) => outcome switch
@@ -43,4 +43,7 @@ public static class TestCaseExtensions
     TestOutcome.NotFound => "not found",
     _ => "",
   };
+
+  private static string? GetStandardOutput(this TestResult testResult) 
+    => testResult.Messages.FirstOrDefault(message => message.Category == TestResultMessage.StandardOutCategory)?.Text;
 }


### PR DESCRIPTION
I find it really useful to see logs in output window :D Idea is to implement it similary like in Rider
<img width="1822" height="598" alt="image" src="https://github.com/user-attachments/assets/a4160777-760b-4561-9c56-69f715cea087" />


Extend existing responses for MTP and VsTests to return standard output