### PR TITLE
feat: dotnet outdated qualify full path

### DIFF
--- a/EasyDotnet.Tool/Controllers/Outdated/OutdatedController.cs
+++ b/EasyDotnet.Tool/Controllers/Outdated/OutdatedController.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using EasyDotnet.Services;
@@ -12,6 +13,7 @@ public class OutdatedController(OutdatedService oudatedService) : BaseController
   [JsonRpcMethod("outdated/packages")]
   public async Task<IAsyncEnumerable<OutdatedDependencyInfoResponse>> GetOutdatedPackages(string targetPath, bool? includeTransitive = false)
   {
+    var fullPath = Path.GetFullPath(targetPath);
     var dependencies = await oudatedService.AnalyzeProjectDependenciesAsync(
                         targetPath,
                         includeTransitive: includeTransitive ?? false,

--- a/EasyDotnet.Tool/EasyDotnet.csproj
+++ b/EasyDotnet.Tool/EasyDotnet.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>2.1.2</Version>
+    <Version>2.1.3</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
The client does send full path. But this change also makes it resilient for when client sends relative path