### PR TITLE
fix: split test error message

### DIFF
--- a/EasyDotnet.Tool/EasyDotnet.csproj
+++ b/EasyDotnet.Tool/EasyDotnet.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>2.1.9</Version>
+    <Version>2.1.10</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <Nullable>enable</Nullable>

--- a/EasyDotnet.Tool/Extensions/TestNodeExtensions.cs
+++ b/EasyDotnet.Tool/Extensions/TestNodeExtensions.cs
@@ -27,7 +27,7 @@ public static class TestNodeExtensions
     Id = test.Node.Uid,
     Outcome = test.Node.ExecutionState,
     Duration = (long?)test.Node.Duration,
-    ErrorMessage = test.Node.Message,
+    ErrorMessage = test.Node.Message?.Split(Environment.NewLine) ?? [],
     StackTrace = (test.Node.StackTrace?.Split(Environment.NewLine) ?? []).AsAsyncEnumerable(),
     StdOut = (test.Node.StandardOutput?.Split(Environment.NewLine) ?? []).AsAsyncEnumerable()
   };

--- a/EasyDotnet.Tool/Types/TestRunResult.cs
+++ b/EasyDotnet.Tool/Types/TestRunResult.cs
@@ -8,6 +8,6 @@ public sealed record TestRunResult
   public required string Outcome { get; init; }
   public required long? Duration { get; init; }
   public required IAsyncEnumerable<string> StackTrace { get; init; }
-  public required string? ErrorMessage { get; init; }
+  public required string[] ErrorMessage { get; init; }
   public required IAsyncEnumerable<string> StdOut { get; init; }
 }

--- a/EasyDotnet.Tool/VSTest/TestCaseExtensions.cs
+++ b/EasyDotnet.Tool/VSTest/TestCaseExtensions.cs
@@ -28,7 +28,7 @@ public static class TestCaseExtensions
   {
     Duration = (long?)x.Duration.TotalMilliseconds,
     StackTrace = (x.ErrorStackTrace?.Split(Environment.NewLine) ?? []).AsAsyncEnumerable(),
-    ErrorMessage = x.ErrorMessage,
+    ErrorMessage = x.ErrorMessage?.Split(Environment.NewLine) ?? [],
     Id = x.TestCase.Id.ToString(),
     Outcome = GetTestOutcome(x.Outcome),
     StdOut = (x.GetStandardOutput()?.Split(Environment.NewLine) ?? []).AsAsyncEnumerable()


### PR DESCRIPTION
Since `StackTrace` and `StdOut` are returned splitted, `ErrorMessage` can also be to avoid additional splitting on lua side