### PR TITLE
fix: MTP discover failing on non-windows

### DIFF
--- a/EasyDotnet.Tool/Controllers/Test/TestController.cs
+++ b/EasyDotnet.Tool/Controllers/Test/TestController.cs
@@ -69,11 +69,9 @@ public class TestController(ClientService clientService, MtpService mtpService, 
     {
       return vsTestService.RunTests(project.TargetPath!, [.. filter.Select(x => Guid.Parse(x.Uid))]).AsAsyncEnumerable();
     }
-
-
   }
 
-  private static string GetExecutablePath(DotnetProjectProperties project) => OperatingSystem.IsWindows() ? Path.ChangeExtension(project.TargetPath!, ".exe") : Path.ChangeExtension(project.TargetPath!, "");
+  private static string GetExecutablePath(DotnetProjectProperties project) => OperatingSystem.IsWindows() ? Path.ChangeExtension(project.TargetPath!, ".exe") : project.TargetPath![..^4];
 
   private async Task<DotnetProjectProperties> GetProject(string projectPath, string? targetFrameworkMoniker, string? configuration, CancellationToken cancellationToken)
   {

--- a/EasyDotnet.Tool/EasyDotnet.csproj
+++ b/EasyDotnet.Tool/EasyDotnet.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>2.1.13</Version>
+    <Version>2.1.14</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
It seems like `Path.ChangeExtension` does not remove the trailing dot if you pass empty string