### PR TITLE
fix(netcoredbg): reset client sequence

### DIFF
--- a/EasyDotnet.IDE/EasyDotnet.IDE.csproj
+++ b/EasyDotnet.IDE/EasyDotnet.IDE.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>2.2.27</Version>
+    <Version>2.2.28</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <Nullable>enable</Nullable>

--- a/EasyDotnet.Infrastructure/Services/NetcoreDbgService.cs
+++ b/EasyDotnet.Infrastructure/Services/NetcoreDbgService.cs
@@ -221,6 +221,7 @@ public partial class NetcoreDbgService(ILogger<NetcoreDbgService> logger, ILogge
 
   public async ValueTask DisposeAsync()
   {
+    _clientSeq = 0;
     if (_cancellationTokenSource?.IsCancellationRequested == false)
     {
       _cancellationTokenSource.Cancel();


### PR DESCRIPTION
Fixes an issue where debugging more than once per session did not work because the client sequence was not being reset correctly when disposing a debugging session