### PR TITLE
feat: roslyn analyzer project

### DIFF
--- a/.github/actions/build-release-with-roslyn/action.yaml
+++ b/.github/actions/build-release-with-roslyn/action.yaml
@@ -42,6 +42,17 @@ runs:
       shell: bash
       run: dotnet build -c Release --no-restore
 
+
+    - name: Build and Copy Custom Analyzer
+      shell: bash
+      run: |
+        OUTPUT_PATH="${{ inputs.roslynOutputPath }}/Roslyn/Analyzers"
+
+        mkdir -p "$OUTPUT_PATH"
+        cp EasyDotnet.RoslynLanguageServices/bin/Release/net8.0/EasyDotnet.RoslynLanguageServices.dll "$OUTPUT_PATH/"
+        
+        echo "✓ Custom analyzer copied to $OUTPUT_PATH"
+
     - name: Download and Extract Roslyn DLLs
       shell: bash
       run: |

--- a/EasyDotnet.IDE/EasyDotnet.IDE.csproj
+++ b/EasyDotnet.IDE/EasyDotnet.IDE.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>2.3.56</Version>
+    <Version>2.3.57</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <Nullable>enable</Nullable>

--- a/EasyDotnet.RoslynLanguageServices/CodeActions/ImportAllNamespacesCodeFixProvider.cs
+++ b/EasyDotnet.RoslynLanguageServices/CodeActions/ImportAllNamespacesCodeFixProvider.cs
@@ -1,0 +1,143 @@
+using System.Collections.Immutable;
+using System.Composition;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace EasyDotnet.RoslynLanguageServices.CodeActions;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ImportAllNamespacesCodeFixProvider)), Shared]
+public class ImportAllNamespacesCodeFixProvider : CodeFixProvider
+{
+  private const string Title = "Import all missing namespaces";
+
+  public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+      ["CS0246"]; // The type or namespace name could not be found
+
+  public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+  public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+  {
+    var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+    var diagnostic = context.Diagnostics[0];
+
+    // Check if there are multiple CS0246 errors in the document
+    var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken);
+    if (semanticModel == null)
+      return;
+
+    var allDiagnostics = semanticModel.GetDiagnostics();
+    var missingTypeDiagnostics = allDiagnostics.Where(d => d.Id == "CS0246").ToList();
+
+    if (missingTypeDiagnostics.Count > 1)
+    {
+      context.RegisterCodeFix(
+          CodeAction.Create(
+              title: Title,
+              createChangedDocument: c => ImportAllMissingNamespacesAsync(context.Document, c),
+              equivalenceKey: Title),
+          diagnostic);
+    }
+  }
+
+  private async Task<Document> ImportAllMissingNamespacesAsync(Document document, CancellationToken cancellationToken)
+  {
+    var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
+    if (semanticModel == null)
+      return document;
+
+    var root = await document.GetSyntaxRootAsync(cancellationToken);
+    if (root == null)
+      return document;
+
+    var compilation = await document.Project.GetCompilationAsync(cancellationToken);
+    if (compilation == null)
+      return document;
+
+    // Find all CS0246 diagnostics
+    var diagnostics = semanticModel.GetDiagnostics(cancellationToken: cancellationToken);
+    var missingTypes = diagnostics
+        .Where(d => d.Id == "CS0246")
+        .Select(d => GetIdentifierFromDiagnostic(root, d))
+        .Where(id => id != null)
+        .Distinct()
+        .ToList();
+
+    var namespacesToAdd = new HashSet<string>();
+
+    // For each missing type, find potential namespaces
+    foreach (var typeName in missingTypes)
+    {
+      foreach (var ns in FindNamespacesForType(compilation, typeName!))
+      {
+        namespacesToAdd.Add(ns);
+      }
+    }
+
+    if (root is not CompilationUnitSyntax compilationUnit)
+      return document;
+
+    var newRoot = compilationUnit;
+    foreach (var ns in namespacesToAdd.Order())
+    {
+      // Check if using already exists
+      if (!compilationUnit.Usings.Any(u => u.Name?.ToString() == ns))
+      {
+        var usingDirective = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(ns))
+            .WithAdditionalAnnotations(Formatter.Annotation);
+        newRoot = newRoot.AddUsings(usingDirective);
+      }
+    }
+
+    return document.WithSyntaxRoot(newRoot);
+  }
+
+  private static string? GetIdentifierFromDiagnostic(SyntaxNode root, Diagnostic diagnostic)
+  {
+    var span = diagnostic.Location.SourceSpan;
+    var node = root.FindNode(span);
+
+    if (node is IdentifierNameSyntax identifier)
+      return identifier.Identifier.Text;
+
+    return node is GenericNameSyntax genericName ? genericName.Identifier.Text : null;
+  }
+
+  private static List<string> FindNamespacesForType(Compilation compilation, string typeName)
+  {
+    var namespaces = new List<string>();
+
+    foreach (var reference in compilation.References)
+    {
+      if (compilation.GetAssemblyOrModuleSymbol(reference) is IAssemblySymbol assembly)
+      {
+        FindTypeInNamespace(assembly.GlobalNamespace, typeName, namespaces);
+      }
+    }
+
+    return namespaces;
+  }
+
+  private static void FindTypeInNamespace(INamespaceSymbol namespaceSymbol, string typeName, List<string> namespaces)
+  {
+    // Check if this namespace contains the type
+    var typeSymbol = namespaceSymbol.GetTypeMembers(typeName).FirstOrDefault();
+    if (typeSymbol != null && typeSymbol.DeclaredAccessibility == Accessibility.Public)
+    {
+      var fullNamespace = namespaceSymbol.ToDisplayString();
+      if (!string.IsNullOrEmpty(fullNamespace))
+      {
+        namespaces.Add(fullNamespace);
+      }
+    }
+
+    // Recursively search child namespaces
+    foreach (var childNamespace in namespaceSymbol.GetNamespaceMembers())
+    {
+      FindTypeInNamespace(childNamespace, typeName, namespaces);
+    }
+  }
+}

--- a/EasyDotnet.RoslynLanguageServices/EasyDotnet.RoslynLanguageServices.csproj
+++ b/EasyDotnet.RoslynLanguageServices/EasyDotnet.RoslynLanguageServices.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/EasyDotnet.sln
+++ b/EasyDotnet.sln
@@ -25,6 +25,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyDotnet.Debugger.Tests",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyDotnet.ProjXLanguageServer", "EasyDotnet.ProjXLanguageServer\EasyDotnet.ProjXLanguageServer.csproj", "{5AB772EA-3A76-41AE-86F1-FB22AFCC0A2D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EasyDotnet.RoslynLanguageServices", "EasyDotnet.RoslynLanguageServices\EasyDotnet.RoslynLanguageServices.csproj", "{5B273057-2229-4B89-B256-DDAA791B7FB4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -167,6 +169,18 @@ Global
 		{5AB772EA-3A76-41AE-86F1-FB22AFCC0A2D}.Release|x64.Build.0 = Release|Any CPU
 		{5AB772EA-3A76-41AE-86F1-FB22AFCC0A2D}.Release|x86.ActiveCfg = Release|Any CPU
 		{5AB772EA-3A76-41AE-86F1-FB22AFCC0A2D}.Release|x86.Build.0 = Release|Any CPU
+		{5B273057-2229-4B89-B256-DDAA791B7FB4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5B273057-2229-4B89-B256-DDAA791B7FB4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5B273057-2229-4B89-B256-DDAA791B7FB4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5B273057-2229-4B89-B256-DDAA791B7FB4}.Debug|x64.Build.0 = Debug|Any CPU
+		{5B273057-2229-4B89-B256-DDAA791B7FB4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5B273057-2229-4B89-B256-DDAA791B7FB4}.Debug|x86.Build.0 = Debug|Any CPU
+		{5B273057-2229-4B89-B256-DDAA791B7FB4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5B273057-2229-4B89-B256-DDAA791B7FB4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5B273057-2229-4B89-B256-DDAA791B7FB4}.Release|x64.ActiveCfg = Release|Any CPU
+		{5B273057-2229-4B89-B256-DDAA791B7FB4}.Release|x64.Build.0 = Release|Any CPU
+		{5B273057-2229-4B89-B256-DDAA791B7FB4}.Release|x86.ActiveCfg = Release|Any CPU
+		{5B273057-2229-4B89-B256-DDAA791B7FB4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
The idea is to establish a project that contains roslyn codeActions/diagnostics/etc that is editor specific and other helpful actions. Things like "search nuget for this type etc", and other cool stuff.

As of commit f6edf9c the code action is being triggered correctly but the implementation is flawed. It will serve as a starting point for future development. You can continue on this work if you want @sebastianstudniczek, hit me up if you have any questions

how to use in easy-dotnet.nvim

```lua
    dotnet.setup {
      lsp = {
        analyzer_assemblies = {"/home/gus/repo/easy-dotnet-server/EasyDotnet.RoslynLanguageServices/bin/Debug/net8.0/EasyDotnet.RoslynLanguageServices.dll"},
      },
}

```

docs: https://learn.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/tutorials/how-to-write-csharp-analyzer-code-fix



After the first code action is created im thinking we bundle the analyzer with the tool and expose an option in neovim setup to enable it (enabled by default)