### PR TITLE
fix: handle missing TargetFramework msbuild prop

### DIFF
--- a/EasyDotnet.IDE/Controllers/MsBuild/ProjectPropertiesResponse.cs
+++ b/EasyDotnet.IDE/Controllers/MsBuild/ProjectPropertiesResponse.cs
@@ -46,7 +46,7 @@ public static class DotnetProjectExtensions
       string testCommand)
   {
     var nugetVersion = project.Version?.ToString();
-    var targetFrameworkVersion = project.TargetFrameworkVersion;
+    var targetFrameworkVersion = project.TargetFrameworkVersion ?? project.TargetFrameworks?.FirstOrDefault();
     var isNetFramework = targetFrameworkVersion?.StartsWith("v4") == true;
     var useIISExpress = project.UseIISExpress;
     var targetPath = project.TargetPath;

--- a/EasyDotnet.IDE/EasyDotnet.IDE.csproj
+++ b/EasyDotnet.IDE/EasyDotnet.IDE.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>2.9.10</Version>
+    <Version>2.9.11</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>


### PR DESCRIPTION
Handle situation when `<TargetFramework>` is not specified and `<TargetFrameworks>` is used instead.
Can't apply both of them since it will give an error

Currently this results in an error when discovering tests
<img width="1840" height="137" alt="image" src="https://github.com/user-attachments/assets/80bf74f0-db59-4123-a583-0ac025d011c9" />
