### PR TITLE
fix(testrunner): duplicate subcases

### DIFF
--- a/EasyDotnet.IDE/EasyDotnet.IDE.csproj
+++ b/EasyDotnet.IDE/EasyDotnet.IDE.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>3.0.0</Version>
+    <Version>3.0.1</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/EasyDotnet.IDE/TestRunner/Executor/OperationExecutor.cs
+++ b/EasyDotnet.IDE/TestRunner/Executor/OperationExecutor.cs
@@ -1,3 +1,4 @@
+using EasyDotnet.Application.Interfaces;
 using EasyDotnet.BuildServer.Contracts;
 using EasyDotnet.IDE.TestRunner.Adapters;
 using EasyDotnet.IDE.TestRunner.Analysis;
@@ -14,6 +15,7 @@ public class OperationExecutor(
     NodeRegistry registry,
     StatusDispatcher dispatcher,
     DetailStore detailStore,
+    IEditorService editorService,
     AdapterResolver adapterResolver,
     ILogger<OperationExecutor> logger)
 {
@@ -32,6 +34,7 @@ public class OperationExecutor(
     var emittedNamespaces = new HashSet<string>();
     var emittedClasses = new HashSet<string>();
     var emittedTheoryGroups = new HashSet<string>();
+    var subcaseCounters = new Dictionary<string, int>();
     var rootNs = project.Raw.RootNamespace ?? project.ProjectName;
     var rootNamespaceParts = rootNs.Split('.', StringSplitOptions.RemoveEmptyEntries);
 
@@ -114,9 +117,27 @@ public class OperationExecutor(
 
           var shortName = discovered.Arguments ?? shortMethodName;
 
-          var methodNodeId = discovered.Arguments is not null
-              ? NodeIdBuilder.Method(parentId, shortMethodName + discovered.Arguments)
-              : NodeIdBuilder.Method(parentId, discovered.MethodName);
+          string methodNodeId;
+          if (discovered.Arguments is not null)
+          {
+            var baseId = NodeIdBuilder.Method(parentId, shortMethodName + discovered.Arguments);
+            subcaseCounters.TryGetValue(baseId, out var seenCount);
+            subcaseCounters[baseId] = seenCount + 1;
+            if (seenCount > 0)
+            {
+              var suffix = $"[{seenCount}]";
+              methodNodeId = NodeIdBuilder.Method(parentId, shortMethodName + discovered.Arguments + suffix);
+              shortName = discovered.Arguments + suffix;
+            }
+            else
+            {
+              methodNodeId = baseId;
+            }
+          }
+          else
+          {
+            methodNodeId = NodeIdBuilder.Method(parentId, discovered.MethodName);
+          }
           var methodNode = new TestNode(
                   Id: methodNodeId,
                   DisplayName: shortName,
@@ -167,7 +188,12 @@ public class OperationExecutor(
     catch (Exception ex)
     {
       logger.LogWarning(ex, "Discovery failed for project {Project} — DLL may be missing or stale", project.ProjectName);
-      await dispatcher.SendStatusAsync(projectNodeId, null);
+      registry.ClearDescendants(projectNodeId);
+      foreach (var orphanId in preDiscoveryIds)
+      {
+        await dispatcher.SendRemoveTestAsync(orphanId);
+      }
+      await editorService.DisplayError($"Discovery failed for project {project.ProjectName} — ${ex.Message}");
     }
   }
 


### PR DESCRIPTION
Fixes an issue where subcases were assigned the same id causing the dictionary to throw an exception

```cs
    [Test]
    [ClassDataSource<DataClass>]
    [ClassDataSource<DataClass>(Shared = SharedType.PerClass)]
    [ClassDataSource<DataClass>(Shared = SharedType.PerAssembly)]
    [ClassDataSource<DataClass>(Shared = SharedType.PerTestSession)]
    public void ClassDataSource(DataClass dataClass)
    {
        Console.WriteLine("This test can accept a class, which can also be pre-initialised before being injected in");

        Console.WriteLine("These can also be shared among other tests, or new'd up each time, by using the `Shared` property on the attribute");
    }
```