### PR TITLE
fix(workspace): launch profile being skipped if use default and none persisted

### DIFF
--- a/EasyDotnet.IDE/AppWrapper/AppWrapperPipeListener.cs
+++ b/EasyDotnet.IDE/AppWrapper/AppWrapperPipeListener.cs
@@ -2,12 +2,14 @@ using System.IO.Pipes;
 using System.Text.Json;
 using EasyDotnet.IDE.Interfaces;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Serialization;
 using StreamJsonRpc;
 
 namespace EasyDotnet.IDE.AppWrapper;
 
 public class AppWrapperPipeListener(
     AppWrapperManager manager,
+    CurrentLogLevel currentLogLevel,
     IEditorProcessManagerService editorProcessManagerService,
     ILogger<AppWrapperPipeListener> logger)
 {
@@ -33,21 +35,26 @@ public class AppWrapperPipeListener(
 
   private Task HandleConnectionAsync(NamedPipeServerStream pipe)
   {
-    var formatter = new SystemTextJsonFormatter
-    {
-      JsonSerializerOptions = new JsonSerializerOptions
-      {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-      }
-    };
-
-    var rpc = new JsonRpc(new HeaderDelimitedMessageHandler(pipe, pipe, formatter));
+    var rpc = new JsonRpc(new HeaderDelimitedMessageHandler(pipe, pipe, CreateJsonMessageFormatter()));
     var handler = new AppWrapperConnectionHandler(manager, editorProcessManagerService, rpc);
+    rpc.TraceSource.Switch.Level = currentLogLevel.Loglevel;
+    rpc.TraceSource.Switch.Level = System.Diagnostics.SourceLevels.Verbose;
+    rpc.TraceSource.Listeners.Clear();
+    rpc.TraceSource.Listeners.Add(new JsonRpcLogger(logger, "AppWrapper"));
     rpc.AddLocalRpcTarget(handler);
     rpc.StartListening();
 
     return rpc.Completion.ContinueWith(
         _ => logger.LogDebug("AppWrapper connection closed."),
         TaskScheduler.Default);
+
   }
+
+  private static JsonMessageFormatter CreateJsonMessageFormatter() => new()
+  {
+    JsonSerializer = { ContractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy()
+            }}
+  };
 }

--- a/EasyDotnet.IDE/AppWrapper/AppWrapperPipeListener.cs
+++ b/EasyDotnet.IDE/AppWrapper/AppWrapperPipeListener.cs
@@ -38,7 +38,6 @@ public class AppWrapperPipeListener(
     var rpc = new JsonRpc(new HeaderDelimitedMessageHandler(pipe, pipe, CreateJsonMessageFormatter()));
     var handler = new AppWrapperConnectionHandler(manager, editorProcessManagerService, rpc);
     rpc.TraceSource.Switch.Level = currentLogLevel.Loglevel;
-    rpc.TraceSource.Switch.Level = System.Diagnostics.SourceLevels.Verbose;
     rpc.TraceSource.Listeners.Clear();
     rpc.TraceSource.Listeners.Add(new JsonRpcLogger(logger, "AppWrapper"));
     rpc.AddLocalRpcTarget(handler);

--- a/EasyDotnet.IDE/EasyDotnet.IDE.csproj
+++ b/EasyDotnet.IDE/EasyDotnet.IDE.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>3.0.27</Version>
+    <Version>3.0.28</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/EasyDotnet.IDE/Workspace/Services/WorkspaceProjectResolver.cs
+++ b/EasyDotnet.IDE/Workspace/Services/WorkspaceProjectResolver.cs
@@ -1,8 +1,6 @@
 using EasyDotnet.BuildServer.Contracts;
-using EasyDotnet.IDE;
 using EasyDotnet.IDE.BuildHost;
 using EasyDotnet.IDE.Interfaces;
-using EasyDotnet.IDE.Models.Client;
 using EasyDotnet.IDE.Models.Client.Prompt;
 using EasyDotnet.IDE.Settings;
 using LaunchProfile = EasyDotnet.IDE.Models.LaunchProfile.LaunchProfile;
@@ -38,8 +36,7 @@ public class WorkspaceProjectResolver(
     return target with { LaunchProfileName = profileName, LaunchProfile = profile };
   }
 
-  private async Task<ResolvedExecutionTarget?> ResolveFromSolutionAsync(
-      string solutionFile, string? filePath, bool useDefault, string operationLabel, CancellationToken ct)
+  private async Task<ResolvedExecutionTarget?> ResolveFromSolutionAsync(string solutionFile, string? filePath, bool useDefault, string operationLabel, CancellationToken ct)
   {
     if (useDefault)
     {
@@ -134,7 +131,6 @@ public class WorkspaceProjectResolver(
         var profile = launchProfileService.GetLaunchProfile(project.ProjectFullPath, settings.LaunchProfile);
         return (settings.LaunchProfile, profile);
       }
-      return (null, null);
     }
 
     var profiles = launchProfileService.GetLaunchProfiles(project.ProjectFullPath);

--- a/EasyDotnet.IDE/Workspace/Services/WorkspaceService.cs
+++ b/EasyDotnet.IDE/Workspace/Services/WorkspaceService.cs
@@ -53,8 +53,7 @@ public class WorkspaceService(
         return;
       }
 
-      var target = await resolver.ResolveAsync(
-          request.FilePath, request.UseDefault, request.UseLaunchProfile, "debug", ct);
+      var target = await resolver.ResolveAsync(request.FilePath, request.UseDefault, request.UseLaunchProfile, "debug", ct);
       if (target is null)
       {
         return;


### PR DESCRIPTION
- If no launch profile was persisted but use default was true it would simply skip prompting and default to null
- Also add some much needed logging to AppWrapper