### PR TITLE
fix: Take conditions into account during PackageReference and TargetFramework diagnostics

### DIFF
--- a/EasyDotnet.IDE/EasyDotnet.IDE.csproj
+++ b/EasyDotnet.IDE/EasyDotnet.IDE.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>3.2.11</Version>
+    <Version>3.2.12</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/EasyDotnet.ProjXLanguageServer.Tests/Diagnostics/ConflictingTargetFrameworkTests.cs
+++ b/EasyDotnet.ProjXLanguageServer.Tests/Diagnostics/ConflictingTargetFrameworkTests.cs
@@ -59,6 +59,23 @@ public class ConflictingTargetFrameworkTests
   }
 
   [Test]
+  public async Task EmptyTargetFramework_SupersedByTargetFrameworks_NoConflict()
+  {
+    var text =
+        """
+        <Project>
+          <PropertyGroup>
+            <TargetFramework />
+            <TargetFrameworks>net48;net10.0</TargetFrameworks>
+          </PropertyGroup>
+        </Project>
+        """;
+    var diagnostics = Build().GetDiagnostics(Docs.Make(text, "/repo/Self/Self.csproj"));
+    var matches = diagnostics.Where(d => d.Code?.Value?.ToString() == DiagnosticCodes.ConflictingTargetFrameworkProperties).ToArray();
+    await Assert.That(matches.Length).IsEqualTo(0);
+  }
+
+  [Test]
   public async Task OnlyTargetFrameworks_NoConflict()
   {
     var text = "<Project>\n  <PropertyGroup>\n    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>\n  </PropertyGroup>\n</Project>";

--- a/EasyDotnet.ProjXLanguageServer.Tests/Diagnostics/DuplicatePackageReferenceTests.cs
+++ b/EasyDotnet.ProjXLanguageServer.Tests/Diagnostics/DuplicatePackageReferenceTests.cs
@@ -50,6 +50,50 @@ public class DuplicatePackageReferenceTests
   }
 
   [Test]
+  public async Task SameReferenceButMutualExclusiveCondition_NoDiagnostics()
+  {
+    var fs = new MockFileSystem();
+    var sut = new DiagnosticsService(fs);
+
+    var text =
+        """
+        <Project>
+          <ItemGroup Condition=" '$(TargetFramework)' != 'net48' ">
+            <PackageReference Include="System.Text.Json" />
+          </ItemGroup>
+          <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+            <PackageReference Include="System.Text.Json" VersionOverride="9.0.10" />
+          </ItemGroup>
+        </Project>
+        """;
+    var diagnostics = sut.GetDiagnostics(Docs.Make(text, "/repo/Self/Self.csproj"));
+    var dupes = diagnostics.Where(d => d.Code?.Value?.ToString() == DiagnosticCodes.DuplicatePackageReference).ToArray();
+    await Assert.That(dupes.Length).IsEqualTo(0);
+  }
+
+  [Test]
+  public async Task DuplicateUnderIdenticalCondition_EmitsDiagnostic()
+  {
+    var fs = new MockFileSystem();
+    var sut = new DiagnosticsService(fs);
+
+    var text =
+        """
+        <Project>
+          <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+            <PackageReference Include="System.Text.Json" Version="9.0.0" />
+          </ItemGroup>
+          <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">
+            <PackageReference Include="System.Text.Json" Version="8.0.0" />
+          </ItemGroup>
+        </Project>
+        """;
+    var diagnostics = sut.GetDiagnostics(Docs.Make(text, "/repo/Self/Self.csproj"));
+    var dupes = diagnostics.Where(d => d.Code?.Value?.ToString() == DiagnosticCodes.DuplicatePackageReference).ToArray();
+    await Assert.That(dupes.Length).IsEqualTo(1);
+  }
+
+  [Test]
   public async Task UniquePackageReferences_NoDiagnostic()
   {
     var fs = new MockFileSystem();

--- a/EasyDotnet.ProjXLanguageServer/Services/DiagnosticsService.cs
+++ b/EasyDotnet.ProjXLanguageServer/Services/DiagnosticsService.cs
@@ -74,7 +74,7 @@ public class DiagnosticsService(IFileSystem fileSystem) : IDiagnosticsService
 
   private static void AddDuplicatePackageReferenceDiagnostics(CsprojDocument doc, List<Diagnostic> diagnostics)
   {
-    var seen = new Dictionary<string, IXmlElementSyntax>(StringComparer.OrdinalIgnoreCase);
+    var seen = new HashSet<(string Include, string Condition)>();
     foreach (var element in EnumerateElements(doc.Root))
     {
       if (!string.Equals(element.Name, "PackageReference", StringComparison.Ordinal))
@@ -88,7 +88,7 @@ public class DiagnosticsService(IFileSystem fileSystem) : IDiagnosticsService
       if (string.IsNullOrWhiteSpace(include))
         continue;
 
-      if (!seen.TryAdd(include, element))
+      if (!seen.Add((include.ToLowerInvariant(), GetConditionSignature(element))))
       {
         var node = (SyntaxNode)element;
         diagnostics.Add(new Diagnostic
@@ -109,17 +109,19 @@ public class DiagnosticsService(IFileSystem fileSystem) : IDiagnosticsService
     {
       if (!string.Equals(element.Name, "TargetFrameworks", StringComparison.Ordinal))
         continue;
-      if (element is not XmlElementSyntax full || full.StartTag == null || full.EndTag == null)
+
+      if (element is not XmlElementSyntax {StartTag: {} start, EndTag: {} end})
         continue;
 
-      var contentStart = full.StartTag.Start + full.StartTag.FullWidth;
-      var contentEnd = full.EndTag.Start;
+      var contentStart = start.Start + start.FullWidth;
+      var contentEnd = end.Start;
       if (contentEnd <= contentStart || contentEnd > doc.Text.Length)
         continue;
 
-      var inner = doc.Text.Substring(contentStart, contentEnd - contentStart);
-      var tfms = inner.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-      if (tfms.Length != 1)
+      // <TargetFrameworks> is a ';'-separated list. After trimming whitespace and any
+      // leading/trailing ';', a remaining ';' means there is more than one TFM.
+      var singleTfm = doc.Text.AsSpan(contentStart, contentEnd - contentStart).Trim().Trim(';').Trim();
+      if (singleTfm.IsEmpty || singleTfm.Contains(';'))
         continue;
 
       var node = (SyntaxNode)element;
@@ -129,7 +131,7 @@ public class DiagnosticsService(IFileSystem fileSystem) : IDiagnosticsService
         Severity = LspDiagnosticSeverity.Warning,
         Source = DiagnosticCodes.Source,
         Code = DiagnosticCodes.SingleTfmInTargetFrameworks,
-        Message = $"<TargetFrameworks> contains a single TFM '{tfms[0]}'; use <TargetFramework> instead.",
+        Message = $"<TargetFrameworks> contains a single TFM '{singleTfm}'; use <TargetFramework> instead.",
       });
     }
   }
@@ -150,7 +152,11 @@ public class DiagnosticsService(IFileSystem fileSystem) : IDiagnosticsService
         continue;
 
       if (string.Equals(name, "TargetFramework", StringComparison.Ordinal))
+      {
+        if (GetElementValue(doc, element).IsWhiteSpace())
+          continue;
         unconditionalSingles.Add(element);
+      }
       else
         unconditionalMultis.Add(element);
     }
@@ -167,7 +173,7 @@ public class DiagnosticsService(IFileSystem fileSystem) : IDiagnosticsService
         Severity = LspDiagnosticSeverity.Error,
         Source = DiagnosticCodes.Source,
         Code = DiagnosticCodes.ConflictingTargetFrameworkProperties,
-        Message = "Cannot specify both <TargetFramework> and <TargetFrameworks>; <TargetFrameworks> takes precedence.",
+        Message = "Cannot specify both <TargetFramework> and <TargetFrameworks>; <TargetFramework> takes precedence.",
       });
     }
   }
@@ -199,6 +205,34 @@ public class DiagnosticsService(IFileSystem fileSystem) : IDiagnosticsService
         Message = $"Closing tag '</{endName}>' does not match opening tag '<{startName}>'.",
       });
     }
+  }
+
+  private static string GetConditionSignature(IXmlElementSyntax element)
+  {
+    var conditions = new List<string>();
+    var current = element;
+    while (current != null)
+    {
+      foreach (var attr in current.AttributesNode)
+      {
+        if (string.Equals(attr.Name, "Condition", StringComparison.OrdinalIgnoreCase))
+          conditions.Add(attr.Value.Trim());
+      }
+      current = current.Parent;
+    }
+    return string.Join(" && ", conditions);
+  }
+
+  private static ReadOnlySpan<char> GetElementValue(CsprojDocument doc, IXmlElementSyntax element)
+  {
+    if (element is not XmlElementSyntax { StartTag: {} start, EndTag: {} end})
+      return default;
+
+    var contentStart = start.Start + start.FullWidth;
+    var contentEnd = end.Start;
+    return contentEnd <= contentStart || contentEnd > doc.Text.Length
+      ? default
+      : doc.Text.AsSpan(contentStart, contentEnd - contentStart);
   }
 
   private static bool HasConditionOnSelfOrAncestor(IXmlElementSyntax element)

--- a/EasyDotnet.ProjXLanguageServer/Services/DiagnosticsService.cs
+++ b/EasyDotnet.ProjXLanguageServer/Services/DiagnosticsService.cs
@@ -110,7 +110,7 @@ public class DiagnosticsService(IFileSystem fileSystem) : IDiagnosticsService
       if (!string.Equals(element.Name, "TargetFrameworks", StringComparison.Ordinal))
         continue;
 
-      if (element is not XmlElementSyntax {StartTag: {} start, EndTag: {} end})
+      if (element is not XmlElementSyntax { StartTag: { } start, EndTag: { } end })
         continue;
 
       var contentStart = start.Start + start.FullWidth;
@@ -225,7 +225,7 @@ public class DiagnosticsService(IFileSystem fileSystem) : IDiagnosticsService
 
   private static ReadOnlySpan<char> GetElementValue(CsprojDocument doc, IXmlElementSyntax element)
   {
-    if (element is not XmlElementSyntax { StartTag: {} start, EndTag: {} end})
+    if (element is not XmlElementSyntax { StartTag: { } start, EndTag: { } end })
       return default;
 
     var contentStart = start.Start + start.FullWidth;


### PR DESCRIPTION
THanks a lot for providing aid to use jetbrains refugees :)

I am however currently in a bad situation in a few of my libraries.

## Flalse positive for `<TargetFrameworks>`

We mostly start with a `Directory.Builds.props` like this.

```xml
<Project>
  <PropertyGroup>
    <TargetFramework>net10.0</TargetFramework>
    <LangVersion>latest</LangVersion>
    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
    <IsPackable>false</IsPackable>
  </PropertyGroup>
  </Project>
  ```

When I now need to target multiple frameworks I have to empty `TargetFramework` 
```xml
<TargetFramework />
<TargetFrameworks>net48;net10.0</TargetFrameworks>
```

This however currently emits invalid diagnostics.    
<img width="2692" height="131" alt="image" src="https://github.com/user-attachments/assets/a3d88cf2-c53b-4490-9740-fe2dcd904739" />

`TargetFramework` wins against `TargetFramworks` so theres no way around it

## Conditions ignored for PackageReferences

Something similiar happens with `VersionOverrides` due to the same reasons I am sometimes forced to do stuff like this

```xml
<ItemGroup Condition=" '$(TargetFramework)' != 'net48' ">
    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
</ItemGroup>
<ItemGroup Condition=" '$(TargetFramework)' != 'net48' ">
    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="8.0.0/>
</ItemGroup>
```

<img width="2692" height="641" alt="image" src="https://github.com/user-attachments/assets/599915e4-8eef-47cd-9cce-2deae99da49d" />


