### PR TITLE
feat(testrunner): sync removed nodes

### DIFF
--- a/EasyDotnet.IDE/EasyDotnet.IDE.csproj
+++ b/EasyDotnet.IDE/EasyDotnet.IDE.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>3.2.12</Version>
+    <Version>3.2.13</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/EasyDotnet.IDE/EasyDotnet.IDE.csproj
+++ b/EasyDotnet.IDE/EasyDotnet.IDE.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>3.3.0</Version>
+    <Version>3.3.1</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/EasyDotnet.IDE/TestRunner/Service/TestRunnerService.cs
+++ b/EasyDotnet.IDE/TestRunner/Service/TestRunnerService.cs
@@ -2,7 +2,6 @@ using EasyDotnet.BuildServer.Contracts;
 using EasyDotnet.IDE.BuildHost;
 using EasyDotnet.IDE.Interfaces;
 using EasyDotnet.IDE.Notifications;
-using EasyDotnet.IDE.TestRunner;
 using EasyDotnet.IDE.TestRunner.Adapters;
 using EasyDotnet.IDE.TestRunner.Analysis;
 using EasyDotnet.IDE.TestRunner.Dispatch;
@@ -706,6 +705,7 @@ public class TestRunnerService(
             NodeType.TheoryGroup => "namespace",
             NodeType.TestMethod => "test",
             NodeType.Subcase => "test",
+            NodeType.ProbableTest => "test",
             _ => null
           };
           if (type is null) return null;
@@ -765,7 +765,11 @@ public class TestRunnerService(
         loc = TestSourceLocator.LookupMethod(parsed.Methods, lookupName);
       }
 
-      if (loc is null) continue;
+      if (loc is null)
+      {
+        registry.RemoveSubtree(node.Id);
+        continue;
+      }
 
       registry.UpdateLineNumbers(node.Id, loc.SignatureLine, loc.BodyStartLine, loc.EndLine);
       updates.Add(new LineNumberUpdateDto(node.Id, loc.SignatureLine, loc.BodyStartLine, loc.EndLine));


### PR DESCRIPTION
Small updates in order to keep neotest tree in sync with file changes. I checked the implementation and saw usage of events (in lua plugin) but I guess the issue is that it's not possible to modify neotest state from outside. We need to keep registry on BE in sync so that when neotest will trigger `discover_positions` for specific file it will get proper results.

- support probable nodes for neotest
- for `SyncFile` remove removed nodes from registry 

Let me know if it this might cause potential issues but tested it and looks like it works without issues