### PR TITLE
fix: testrunner regressions

### DIFF
--- a/EasyDotnet.ContainerTests/Docker/LinuxServerContainers.cs
+++ b/EasyDotnet.ContainerTests/Docker/LinuxServerContainers.cs
@@ -22,6 +22,26 @@ public abstract class LinuxServerContainer(string image) : ServerContainer
       .WithEnvironment("DOTNET_NOLOGO", "1");
 
   /// <summary>
+  /// The container writes its NuGet cache + tool install into <see cref="_homePath"/>, which
+  /// lives under the bind-mounted <c>/tmp</c> and so survives on the host after <c>docker rm</c>.
+  /// Delete it on teardown so these (~tens of MB each) don't accumulate across runs and fill /tmp.
+  /// </summary>
+  protected override ValueTask OnAfterDisposeAsync()
+  {
+    try
+    {
+      if (Directory.Exists(_homePath))
+        Directory.Delete(_homePath, recursive: true);
+    }
+    catch (Exception ex)
+    {
+      Console.WriteLine($"Home dir cleanup failed for '{_homePath}': {ex}");
+    }
+
+    return ValueTask.CompletedTask;
+  }
+
+  /// <summary>
   /// Runs the container as the same UID:GID as the test process so the Unix Domain
   /// Socket at /tmp/CoreFxPipe_* is writable by the host process connecting from outside.
   /// </summary>

--- a/EasyDotnet.ContainerTests/Docker/ServerContainer.cs
+++ b/EasyDotnet.ContainerTests/Docker/ServerContainer.cs
@@ -197,6 +197,13 @@ public abstract class ServerContainer : IAsyncDisposable
   protected virtual Task OnBeforeStartAsync(CancellationToken ct) => Task.CompletedTask;
 
   /// <summary>
+  /// Called at the end of <see cref="DisposeAsync"/> after the container has been removed.
+  /// Override to clean up host-side artifacts the container wrote through bind mounts
+  /// (e.g. a per-container HOME under <c>/tmp</c>) so they don't accumulate across runs.
+  /// </summary>
+  protected virtual ValueTask OnAfterDisposeAsync() => ValueTask.CompletedTask;
+
+  /// <summary>
   /// Called with the <see cref="JsonRpc"/> instance immediately before <see cref="JsonRpc.StartListening"/>.
   /// Override to register local RPC method handlers for server-initiated reverse requests
   /// (e.g. <c>promptSelection</c>, <c>runCommandManaged</c>) via
@@ -254,5 +261,7 @@ public abstract class ServerContainer : IAsyncDisposable
     {
       Console.WriteLine($"Tool install cleanup failed for '{_toolInstallPath}': {ex}");
     }
+
+    await OnAfterDisposeAsync();
   }
 }

--- a/EasyDotnet.ContainerTests/TestRunner/Fixtures/TestFixtures.cs
+++ b/EasyDotnet.ContainerTests/TestRunner/Fixtures/TestFixtures.cs
@@ -258,6 +258,26 @@ public static class TestFixtures
     """;
 
   /// <summary>
+  /// One passing and one failing xUnit fact in the same class. Used to assert the
+  /// runner reports a Failed terminal status on the failing leaf and aggregates the
+  /// failure up to the parent class. Source shared between xUnit v2 and v3.
+  /// </summary>
+  public const string XUnitPassingAndFailing = """
+    using Xunit;
+
+    namespace Sample.PassFail;
+
+    public class Cases
+    {
+        [Fact]
+        public void Passes() => Assert.True(true);
+
+        [Fact]
+        public void Fails() => Assert.True(false);
+    }
+    """;
+
+  /// <summary>
   /// Expected 0-based line positions for <see cref="XUnitLocationMarker"/>.
   /// </summary>
   public static class XUnitLocationLines

--- a/EasyDotnet.ContainerTests/TestRunner/XUnitV2VsTestDiscoveryTests.cs
+++ b/EasyDotnet.ContainerTests/TestRunner/XUnitV2VsTestDiscoveryTests.cs
@@ -192,6 +192,127 @@ public abstract class XUnitV2VsTestDiscoveryTests<TContainer> : TestRunnerTestBa
     Assert.NotNull(methodWithRunning);
   }
 
+  [Fact]
+  public async Task SyncFile_OnFSharpFile_KeepsNodesAndRunStillReportsResults()
+  {
+    using var fixture = new TestProjectFixtureBuilder()
+      .WithName("Sample.FSharpXUnitV2SyncRun")
+      .WithFramework(TestFrameworkKind.XUnitV2VsTestFSharp)
+      .WithFile("Tests.fs", TestFixtures.FSharpXUnitMixedDottedNames)
+      .Build();
+
+    await InitializeTestRunnerAsync(fixture);
+
+    Assert.Equal(2, NodesOfType(NodeTypeNames.TestMethod).Count());
+
+    // The Roslyn source locator is C#-only, so syncing an .fs file finds no methods.
+    // The server must NOT treat that as "every test was deleted" and wipe the nodes —
+    // that regression made a subsequent run bail with nothing to execute.
+    var fsPath = Path.Combine(fixture.ProjectDir, "Tests.fs");
+    await Container.Rpc.TestRunnerSyncFileAsync(fsPath, TestFixtures.FSharpXUnitMixedDottedNames, version: 1);
+
+    Assert.True(
+      NodesOfType(NodeTypeNames.TestMethod).Count() == 2,
+      $"syncFile on an .fs file must not remove discovered nodes. Node dump:\n{DumpNodes()}");
+
+    // And a run after the sync must still discover + execute the tests.
+    var project = Assert.Single(NodesOfType(NodeTypeNames.Project));
+    await BeginCall(Container.Rpc.TestRunnerRunAsync(project.Id), TimeSpan.FromMinutes(2));
+
+    Assert.All(NodesOfType(NodeTypeNames.TestMethod), method =>
+      Assert.True(
+        LastStatusKind.TryGetValue(method.Id, out var kind) && kind == "Passed",
+        $"Expected F# test {method.DisplayName} to pass after syncFile. Node dump:\n{DumpNodes()}"));
+  }
+
+  [Fact]
+  public async Task Run_ProjectWithFailingTest_ReportsFailedLeafAndAggregatesToParent()
+  {
+    using var fixture = new TestProjectFixtureBuilder()
+      .WithName("Sample.XUnitV2PassFail")
+      .WithFramework(TestFrameworkKind.XUnitV2VsTest)
+      .WithFile("Cases.cs", TestFixtures.XUnitPassingAndFailing)
+      .Build();
+
+    await InitializeTestRunnerAsync(fixture);
+
+    var project = Assert.Single(NodesOfType(NodeTypeNames.Project));
+    var testClass = Assert.Single(NodesOfType(NodeTypeNames.TestClass), n => n.DisplayName == "Cases");
+    var passes = Assert.Single(NodesOfType(NodeTypeNames.TestMethod), n => n.DisplayName == "Passes");
+    var fails = Assert.Single(NodesOfType(NodeTypeNames.TestMethod), n => n.DisplayName == "Fails");
+
+    await BeginCall(Container.Rpc.TestRunnerRunAsync(project.Id), TimeSpan.FromMinutes(2));
+
+    Assert.Equal("Passed", LastStatusKind.GetValueOrDefault(passes.Id));
+    Assert.Equal("Failed", LastStatusKind.GetValueOrDefault(fails.Id));
+
+    // A single failing child must drag the parent class aggregate to Failed.
+    Assert.Equal("Failed", LastStatusKind.GetValueOrDefault(testClass.Id));
+
+    Assert.NotNull(LastRunnerStatus);
+    Assert.Equal(1, LastRunnerStatus!.TotalPassed);
+    Assert.Equal(1, LastRunnerStatus.TotalFailed);
+  }
+
+  [Fact]
+  public async Task RunSolution_AfterTestRemovedFromSource_PrunesStaleTestAndRunsSurvivor()
+  {
+    const string twoMethods = """
+      using Xunit;
+
+      namespace Sample.SolutionPrune;
+
+      public class C
+      {
+          [Fact]
+          public void Keep() => Assert.True(true);
+
+          [Fact]
+          public void Removed() => Assert.True(true);
+      }
+      """;
+
+    const string onlyKeep = """
+      using Xunit;
+
+      namespace Sample.SolutionPrune;
+
+      public class C
+      {
+          [Fact]
+          public void Keep() => Assert.True(true);
+      }
+      """;
+
+    using var fixture = new TestProjectFixtureBuilder()
+      .WithName("Sample.XUnitV2SolutionPrune")
+      .WithFramework(TestFrameworkKind.XUnitV2VsTest)
+      .WithFile("Tests.cs", twoMethods)
+      .Build();
+
+    await InitializeTestRunnerAsync(fixture);
+
+    // Both tests are discovered from the freshly built DLL at open time.
+    var keep = Assert.Single(NodesOfType(NodeTypeNames.TestMethod), n => n.DisplayName == "Keep");
+    Assert.Single(NodesOfType(NodeTypeNames.TestMethod), n => n.DisplayName == "Removed");
+
+    // Delete one test from source without re-discovering. The node is now stale: still
+    // in the tree (and the on-disk DLL), but gone from source.
+    await File.WriteAllTextAsync(Path.Combine(fixture.ProjectDir, "Tests.cs"), onlyKeep);
+
+    // Running the whole solution must rebuild + re-discover, pruning the removed test
+    // before the run. Before the fix the solution path skipped discovery, so "Removed"
+    // lingered with no status while the run executed the stale node set.
+    var solution = Assert.Single(NodesOfType(NodeTypeNames.Solution));
+    await BeginCall(Container.Rpc.TestRunnerRunAsync(solution.Id), TimeSpan.FromMinutes(2));
+
+    var survivors = NodesOfType(NodeTypeNames.TestMethod).ToList();
+    Assert.True(
+      survivors.Count == 1 && survivors[0].DisplayName == "Keep",
+      $"Expected only 'Keep' to remain after the solution run. Node dump:\n{DumpNodes()}");
+    Assert.Equal("Passed", LastStatusKind.GetValueOrDefault(keep.Id));
+  }
+
   private string DumpNodes() =>
     string.Join("\n", Nodes.Values
       .OrderBy(n => n.Id)

--- a/EasyDotnet.ContainerTests/TestRunner/XUnitV3MtpDiscoveryTests.cs
+++ b/EasyDotnet.ContainerTests/TestRunner/XUnitV3MtpDiscoveryTests.cs
@@ -176,6 +176,41 @@ public abstract class XUnitV3MtpDiscoveryTests<TContainer> : TestRunnerTestBase<
     Assert.NotNull(methodWithRunning);
   }
 
+  [Fact]
+  public async Task Run_SingleTestMethod_RunsThatLeafAndLeavesSiblingsUntouched()
+  {
+    using var fixture = new TestProjectFixtureBuilder()
+      .WithName("Sample.XUnitV3SingleLeaf")
+      .WithFramework(TestFrameworkKind.XUnitV3Mtp)
+      .WithFile("SlowTests.cs", TestFixtures.XUnitSlowTests)
+      .Build();
+
+    await InitializeTestRunnerAsync(fixture);
+
+    var methods = NodesOfType(NodeTypeNames.TestMethod).ToList();
+    Assert.Equal(3, methods.Count);
+
+    var target = Assert.Single(methods, m => m.DisplayName == "A");
+
+    await BeginCall(Container.Rpc.TestRunnerRunAsync(target.Id), TimeSpan.FromMinutes(2));
+
+    // The leaf we asked for must run end-to-end. This is the path that regressed:
+    // running a single discovered leaf re-discovers, then RunNodeAsync executes only
+    // that node — before the fix it could bail after discovery with no run at all.
+    Assert.True(
+      StatusHistory.TryGetValue(target.Id, out var history) &&
+        HistoryContainsInOrder(history, "Queued", "Running", "Passed"),
+      $"Expected {target.DisplayName} to go Queued→Running→Passed. Node dump:\n{DumpNodes()}");
+
+    // The other two leaves were not in the run set, so they must never have started.
+    foreach (var sibling in methods.Where(m => m.Id != target.Id))
+    {
+      Assert.False(
+        LastStatusKind.TryGetValue(sibling.Id, out var kind) && kind is "Running" or "Passed" or "Failed",
+        $"Sibling {sibling.DisplayName} should not have run, but saw status '{kind}'.");
+    }
+  }
+
   private string DumpNodes() =>
     string.Join("\n", Nodes.Values
       .OrderBy(n => n.Id)

--- a/EasyDotnet.IDE/EasyDotnet.IDE.csproj
+++ b/EasyDotnet.IDE/EasyDotnet.IDE.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>3.3.1</Version>
+    <Version>3.3.2</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/EasyDotnet.IDE/TestRunner/Service/TestRunnerService.cs
+++ b/EasyDotnet.IDE/TestRunner/Service/TestRunnerService.cs
@@ -107,7 +107,6 @@ public class TestRunnerService(
 
   public async Task<InitializeResult> InitializeAsync(string solutionPath, CancellationToken ct)
   {
-    // Fast path: already initialized, avoid MSBuild entirely.
     if (_isInitialized) return new InitializeResult(Success: true);
 
     var opCts = new CancellationTokenSource();
@@ -116,7 +115,6 @@ public class TestRunnerService(
     using var token = await operationLock.WaitAcquireAsync("initialize", ct, opCts.Token);
     TrackOperationStart(token, opCts, control);
 
-    // Double-check after acquiring the lock: another caller may have initialized while we waited.
     if (_isInitialized)
     {
       TrackOperationEnd(token);
@@ -290,10 +288,8 @@ public class TestRunnerService(
       if (_operationCts is null || _operationControl is null || _operationId == 0 || _operationStage == OperationStage.Idle)
         return;
 
-      // Snapshot for use outside the lock.
       snap = (_operationStage, _operationId, _operationCts, _operationControl);
 
-      // Transition (1st cancel => cancelling, 2nd => killing)
       _operationStage = _operationStage switch
       {
         OperationStage.Running => OperationStage.Cancelling,
@@ -313,26 +309,20 @@ public class TestRunnerService(
 
     if (stage != OperationStage.Cancelling)
     {
-      // Already killing — idempotent.
       return;
     }
 
-    // Cancelling → escalate to kill.
     await dispatcher.SendRunnerStatusAsync(BuildKillingStatus(), operationId);
     try { cts.Cancel(); } catch { }
 
-    // Hard stop external resources (best effort).
     try { await control.KillAsync(timeout: TimeSpan.FromSeconds(2)); } catch { }
 
-    // Prefer the "normal" path: let the operation unwind and release the semaphore.
     var released = await WaitForUnlockAsync(operationId, timeout: TimeSpan.FromSeconds(2), ct);
 
     if (!released)
     {
-      // Last resort: recover usability even if the underlying operation is stuck.
       operationLock.ForceReleaseIfHeld();
 
-      // Clear local state so new operations can proceed immediately.
       lock (_opSync)
       {
         if (_operationId == operationId)
@@ -345,7 +335,6 @@ public class TestRunnerService(
       }
     }
 
-    // Reset UI regardless of operationId gating.
     await ResetTransientNodesAsync(operationId: null, markCancelled: true);
     await dispatcher.SendRunnerStatusAsync(BuildKilledStatus(), operationId: null);
 
@@ -744,12 +733,8 @@ public class TestRunnerService(
     var parsed = TestSourceLocator.ParseContent(req.Content);
     var updates = new List<LineNumberUpdateDto>();
 
-    // The source locator is C#-only — a non-.cs file parses to an empty method
-    // map, so every node would falsely look "deleted". Only trust a locator miss
-    // as a real deletion for C# files.
     var isCSharp = req.Path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase);
 
-    // --- 1. Update line numbers for all already-registered nodes in this file ---
     foreach (var node in registry.GetNodesForFile(req.Path))
     {
       TestMethodLocation? loc;
@@ -772,10 +757,6 @@ public class TestRunnerService(
 
       if (loc is null)
       {
-        // Only treat a locator miss as a real deletion when the signal is
-        // trustworthy: the file is C# (the locator can parse it) and no run/
-        // discovery is in flight (whose results depend on this node + its native
-        // mapping). Otherwise leave the node — discovery reconciles deletions.
         if (isCSharp && !operationLock.IsLocked)
           registry.RemoveSubtree(node.Id);
         continue;
@@ -785,17 +766,11 @@ public class TestRunnerService(
       updates.Add(new LineNumberUpdateDto(node.Id, loc.SignatureLine, loc.BodyStartLine, loc.EndLine));
     }
 
-    // --- 2. Synthesise ProbableTest nodes for newly-written test methods ---
-    //
-    // Only methods whose containing class IS already in the registry can get a
-    // probable node — we need the classNodeId to build the stable ID.
     var existingProbableIds = registry.GetNodesForFile(req.Path)
         .Where(n => n.Type is NodeType.ProbableTest)
         .Select(n => n.Id)
         .ToHashSet(StringComparer.Ordinal);
 
-    // Build a set of signature lines already occupied by real (non-probable) nodes.
-    // Any probable method whose line overlaps a real node is discarded — it's already discovered.
     var realNodeLines = registry.GetNodesForFile(req.Path)
         .Where(n => n.Type is not NodeType.ProbableTest && n.SignatureLine.HasValue)
         .Select(n => n.SignatureLine!.Value)
@@ -805,11 +780,9 @@ public class TestRunnerService(
 
     foreach (var probable in parsed.ProbableMethods)
     {
-      // Discard if any real node already occupies the same signature line
       if (realNodeLines.Contains(probable.Location.SignatureLine))
         continue;
 
-      // Find the registered class node for this file + class name
       var classNode = registry.GetNodesForFile(req.Path)
           .FirstOrDefault(n =>
               n.Type is NodeType.TestClass &&
@@ -824,13 +797,11 @@ public class TestRunnerService(
       var existing = registry.Get(probableId);
       if (existing?.Type is NodeType.ProbableTest)
       {
-        // Already known probable — update line numbers and include in updates
         registry.UpdateLineNumbers(probableId, probable.Location.SignatureLine, probable.Location.BodyStartLine, probable.Location.EndLine);
         updates.Add(new LineNumberUpdateDto(probableId, probable.Location.SignatureLine, probable.Location.BodyStartLine, probable.Location.EndLine));
         continue;
       }
 
-      // New probable — synthesise FQN by walking up through namespace segments
       var fqn = BuildFqn(classNode, probable.MethodName);
 
       var probableNode = new TestNode(
@@ -852,7 +823,6 @@ public class TestRunnerService(
       updates.Add(new LineNumberUpdateDto(probableId, probable.Location.SignatureLine, probable.Location.BodyStartLine, probable.Location.EndLine));
     }
 
-    // --- 3. Remove probable nodes whose methods are no longer in the source ---
     foreach (var staleId in existingProbableIds)
     {
       if (newProbableIds.Contains(staleId)) continue;
@@ -1019,10 +989,6 @@ public class TestRunnerService(
       return new OperationResult(Success: failedProjectIds.Count == 0);
     }
 
-    // Re-discover every runnable project against the freshly built DLLs before running,
-    // exactly like ExecuteSingleProjectAsync does. Without this a solution run executes
-    // the stale node set (whatever was discovered when the runner opened) against the new
-    // assemblies, so tests removed from source linger and never report a result.
     await dispatcher.SendRunnerStatusAsync(BuildLoadingStatus("Discovering", OverallStatus.Discovering), token.OperationId);
     await Task.WhenAll(runnableProjects.Select(p =>
     {
@@ -1087,10 +1053,6 @@ public class TestRunnerService(
     var project = await ResolveProjectAsync(projectId, token.Ct)
         ?? throw new InvalidOperationException($"Project {projectId} not found");
 
-    // Snapshot probable metadata before re-discovery wipes the node. After discovery
-    // we try to resolve the successor (real TestMethod / TheoryGroup) by file + class +
-    // method name — adapters disagree on whether discovered.MethodName is short or FQN,
-    // so the probable's stable id doesn't always survive rediscovery.
     var probableSnapshot = node.Type is NodeType.ProbableTest
         ? (FilePath: node.FilePath, ParentId: node.ParentId, MethodName: node.DisplayName)
         : default;
@@ -1131,10 +1093,6 @@ public class TestRunnerService(
       return new OperationResult(Success: false);
     }
 
-    // Re-discover after a successful build so any newly-written tests (with or
-    // without probable nodes) are registered and emitted to the client before
-    // RunNodeAsync collects its leaf set.  This also covers MTP, which has no
-    // internal pre-run discovery of its own.
     var solutionNodeId = registry.Get(projectId)?.ParentId;
     if (solutionNodeId is not null)
     {
@@ -1142,8 +1100,6 @@ public class TestRunnerService(
       await executor.DiscoverProjectAsync(project, solutionNodeId, control, token);
     }
 
-    // If the caller handed us a ProbableTest id that discovery just replaced under a
-    // different stable id, redirect to the successor so this first run actually fires.
     var runNodeId = ResolveProbableSuccessor(nodeId, probableSnapshot);
 
     await dispatcher.SendRunnerStatusAsync(BuildLoadingStatus(debug ? "Debugging" : "Running", debug ? OverallStatus.Debugging : OverallStatus.Running), token.OperationId);

--- a/EasyDotnet.IDE/TestRunner/Service/TestRunnerService.cs
+++ b/EasyDotnet.IDE/TestRunner/Service/TestRunnerService.cs
@@ -744,6 +744,11 @@ public class TestRunnerService(
     var parsed = TestSourceLocator.ParseContent(req.Content);
     var updates = new List<LineNumberUpdateDto>();
 
+    // The source locator is C#-only — a non-.cs file parses to an empty method
+    // map, so every node would falsely look "deleted". Only trust a locator miss
+    // as a real deletion for C# files.
+    var isCSharp = req.Path.EndsWith(".cs", StringComparison.OrdinalIgnoreCase);
+
     // --- 1. Update line numbers for all already-registered nodes in this file ---
     foreach (var node in registry.GetNodesForFile(req.Path))
     {
@@ -767,7 +772,12 @@ public class TestRunnerService(
 
       if (loc is null)
       {
-        registry.RemoveSubtree(node.Id);
+        // Only treat a locator miss as a real deletion when the signal is
+        // trustworthy: the file is C# (the locator can parse it) and no run/
+        // discovery is in flight (whose results depend on this node + its native
+        // mapping). Otherwise leave the node — discovery reconciles deletions.
+        if (isCSharp && !operationLock.IsLocked)
+          registry.RemoveSubtree(node.Id);
         continue;
       }
 
@@ -1008,6 +1018,19 @@ public class TestRunnerService(
       await dispatcher.SendRunnerStatusAsync(BuildIdleStatus(), token.OperationId);
       return new OperationResult(Success: failedProjectIds.Count == 0);
     }
+
+    // Re-discover every runnable project against the freshly built DLLs before running,
+    // exactly like ExecuteSingleProjectAsync does. Without this a solution run executes
+    // the stale node set (whatever was discovered when the runner opened) against the new
+    // assemblies, so tests removed from source linger and never report a result.
+    await dispatcher.SendRunnerStatusAsync(BuildLoadingStatus("Discovering", OverallStatus.Discovering), token.OperationId);
+    await Task.WhenAll(runnableProjects.Select(p =>
+    {
+      var pn = projectNodes.First(n => string.Equals(n.FilePath, p.ProjectFullPath, StringComparison.OrdinalIgnoreCase));
+      return executor.DiscoverProjectAsync(p, pn.ParentId ?? nodeId, control, token);
+    }));
+
+    token.Ct.ThrowIfCancellationRequested();
 
     var totalLeafCount = runnableProjects
         .Sum(p =>


### PR DESCRIPTION
- fix `/tmp` folder leak when running ContainerTests
- fix node not found when doing a solution run