### PR TITLE
fix: settings service file locking issues

### DIFF
--- a/EasyDotnet.IDE.Tests/Settings/SettingsSerializerTests.cs
+++ b/EasyDotnet.IDE.Tests/Settings/SettingsSerializerTests.cs
@@ -40,7 +40,6 @@ public class SettingsSerializerTests
     await Assert.That(result).IsNotNull();
     await Assert.That(result?.Defaults?.TestProject).IsEqualTo("SomeTest");
 
-
     var afterRead = _fileSystem.File.ReadAllText(TestPath);
     await Assert.That(afterRead).IsEqualTo(json);
   }

--- a/EasyDotnet.IDE.Tests/Settings/SettingsSerializerTests.cs
+++ b/EasyDotnet.IDE.Tests/Settings/SettingsSerializerTests.cs
@@ -29,9 +29,8 @@ public class SettingsSerializerTests
   }
 
   [Test]
-  public async Task Read_ValidJson_ReturnsSettingsAndUpdateLastAccessed()
+  public async Task Read_ValidJson_ReturnsSettingsWithoutMutatingFile()
   {
-    var originalTime = DateTime.UtcNow.AddDays(-1);
     var settings = new SolutionSettings() { Metadata = new() { OriginalPath = "/tmp" }, Defaults = new() { TestProject = "SomeTest" } };
     var json = JsonSerializer.Serialize(settings, new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
     _fileSystem.AddFile(TestPath, new MockFileData(json));
@@ -40,10 +39,11 @@ public class SettingsSerializerTests
 
     await Assert.That(result).IsNotNull();
     await Assert.That(result?.Defaults?.TestProject).IsEqualTo("SomeTest");
-    await Assert.That(result!.Metadata!.LastAccessed).IsGreaterThan(originalTime);
 
-    var updatedJson = _fileSystem.File.ReadAllText(TestPath);
-    await Assert.That(updatedJson).Contains("lastAccessed");
+    // Read is a pure read — it must not write the file back (no lock contention,
+    // no LastAccessed touch). The on-disk content stays byte-for-byte identical.
+    var afterRead = _fileSystem.File.ReadAllText(TestPath);
+    await Assert.That(afterRead).IsEqualTo(json);
   }
 
   [Test]

--- a/EasyDotnet.IDE.Tests/Settings/SettingsSerializerTests.cs
+++ b/EasyDotnet.IDE.Tests/Settings/SettingsSerializerTests.cs
@@ -40,8 +40,7 @@ public class SettingsSerializerTests
     await Assert.That(result).IsNotNull();
     await Assert.That(result?.Defaults?.TestProject).IsEqualTo("SomeTest");
 
-    // Read is a pure read — it must not write the file back (no lock contention,
-    // no LastAccessed touch). The on-disk content stays byte-for-byte identical.
+
     var afterRead = _fileSystem.File.ReadAllText(TestPath);
     await Assert.That(afterRead).IsEqualTo(json);
   }

--- a/EasyDotnet.IDE/EasyDotnet.IDE.csproj
+++ b/EasyDotnet.IDE/EasyDotnet.IDE.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>3.3.2</Version>
+    <Version>3.3.3</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/EasyDotnet.IDE/Settings/SettingsSerializer.cs
+++ b/EasyDotnet.IDE/Settings/SettingsSerializer.cs
@@ -42,10 +42,6 @@ public class SettingsSerializer(IFileSystem fileSystem, ILogger<SettingsSerializ
         return default;
       }
 
-      // Intentionally a pure read: no write-back here. LastAccessed is bumped on
-      // real saves instead. Touching the file on every read doubled lock exposure
-      // on Windows (and made the GC's own scan mutate the files it reads), and a
-      // lost lock race on that cosmetic write would discard settings we read fine.
       return settings;
     }
     catch (JsonException ex)

--- a/EasyDotnet.IDE/Settings/SettingsSerializer.cs
+++ b/EasyDotnet.IDE/Settings/SettingsSerializer.cs
@@ -42,10 +42,10 @@ public class SettingsSerializer(IFileSystem fileSystem, ILogger<SettingsSerializ
         return default;
       }
 
-      // Update last accessed time
-      settings.Metadata.LastAccessed = DateTime.UtcNow;
-      Write(filePath, settings);
-
+      // Intentionally a pure read: no write-back here. LastAccessed is bumped on
+      // real saves instead. Touching the file on every read doubled lock exposure
+      // on Windows (and made the GC's own scan mutate the files it reads), and a
+      // lost lock race on that cosmetic write would discard settings we read fine.
       return settings;
     }
     catch (JsonException ex)


### PR DESCRIPTION
Fixes a concurrency issue where windows throws `[16:36:33 ERR] Failed to write settings file: System.IO.IOException: The process cannot access the file 'x.json' because it is being used by another process. `