### PR TITLE
feat(test-runner): discovery adjustments

### DIFF
--- a/EasyDotnet.IDE/EasyDotnet.IDE.csproj
+++ b/EasyDotnet.IDE/EasyDotnet.IDE.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>3.4.11</Version>
+    <Version>3.4.12</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/EasyDotnet.IDE/TestRunner/Analysis/TestSourceLocator.cs
+++ b/EasyDotnet.IDE/TestRunner/Analysis/TestSourceLocator.cs
@@ -11,7 +11,8 @@ namespace EasyDotnet.IDE.TestRunner.Analysis;
 public record TestMethodLocation(
     int SignatureLine,   // [Fact] / [Test] attribute line (or class keyword line) — where the gutter sign goes
     int BodyStartLine,   // first line inside the opening brace — where go-to-definition lands
-    int EndLine          // closing brace line
+    int EndLine,         // closing brace line
+    bool HasNonTheoryAttribute = false   // If test has argument that doesn't mean it's of theory type (example for TUnit [ClassDataSource] attribute)
 );
 
 /// <summary>
@@ -122,6 +123,12 @@ public class TestSourceLocator
     "InlineData", "DataRow", "Arguments",
   };
 
+  // Not all tests with arguments are of Theory type
+  private static readonly HashSet<string> NonTheoryAttributes = new(StringComparer.Ordinal)
+  {
+    "ClassDataSource"
+  };
+
   private static bool HasTestAttribute(MethodDeclarationSyntax method) =>
       method.AttributeLists
           .SelectMany(al => al.Attributes)
@@ -135,6 +142,20 @@ public class TestSourceLocator
             };
             return TestAttributeNames.Contains(name);
           });
+
+  private static bool HasNonTheoryAttribute(MethodDeclarationSyntax method) =>
+    method.AttributeLists
+      .SelectMany(al => al.Attributes)
+      .Any(a =>
+      {
+        var name = a.Name switch
+        {
+          GenericNameSyntax q => q.Identifier.Text,
+          _ => a.Name.ToString(),
+        };
+        return NonTheoryAttributes.Contains(name);
+      });
+
 
   private static string? EnclosingClassName(MethodDeclarationSyntax method) =>
       (method.Parent as ClassDeclarationSyntax)?.Identifier.Text;
@@ -176,7 +197,8 @@ public class TestSourceLocator
       }
 
       var endLine = method.GetLocation().GetLineSpan().EndLinePosition.Line;
-      var loc = new TestMethodLocation(signatureLine, bodyStartLine, endLine);
+      var hasNonTheoryAttribute = HasNonTheoryAttribute(method);
+      var loc = new TestMethodLocation(signatureLine, bodyStartLine, endLine, hasNonTheoryAttribute);
 
       methods[name] = loc;
 

--- a/EasyDotnet.IDE/TestRunner/Executor/OperationExecutor.cs
+++ b/EasyDotnet.IDE/TestRunner/Executor/OperationExecutor.cs
@@ -90,7 +90,8 @@ public class OperationExecutor(
 
           var location = locator.Locate(discovered.FilePath, shortMethodName);
 
-          if (discovered.Arguments is not null)
+          var isTheoryGroup = discovered.Arguments is not null && !(location?.HasNonTheoryAttribute ?? false);
+          if (isTheoryGroup)
           {
             var groupId = NodeIdBuilder.TheoryGroup(parentId, shortMethodName);
             if (emittedTheoryGroups.Add(groupId))
@@ -118,7 +119,7 @@ public class OperationExecutor(
           var shortName = discovered.Arguments ?? shortMethodName;
 
           string methodNodeId;
-          if (discovered.Arguments is not null)
+          if (isTheoryGroup)
           {
             var baseId = NodeIdBuilder.Method(parentId, shortMethodName + discovered.Arguments);
             subcaseCounters.TryGetValue(baseId, out var seenCount);
@@ -160,7 +161,7 @@ public class OperationExecutor(
                   SignatureLine: location?.SignatureLine,
                   BodyStartLine: location?.BodyStartLine,
                   EndLine: location?.EndLine,
-                  Type: discovered.Arguments is not null
+                  Type: isTheoryGroup
                       ? new NodeType.Subcase()
                       : new NodeType.TestMethod(),
                   ProjectId: projectNodeId,

--- a/EasyDotnet.IDE/TestRunner/Executor/OperationExecutor.cs
+++ b/EasyDotnet.IDE/TestRunner/Executor/OperationExecutor.cs
@@ -65,7 +65,12 @@ public class OperationExecutor(
             var classNodeId = NodeIdBuilder.Class(namespaceNodeId, discovered.ClassName);
             if (emittedClasses.Add(classNodeId))
             {
-              var classLocation = locator.LocateClass(discovered.FilePath, discovered.ClassName);
+              // Ignore potential primary constructor arguments
+              var shortClassName = discovered.ClassName.Contains('(')
+                ? discovered.ClassName[..(discovered.ClassName.IndexOf('('))]
+                : discovered.ClassName;
+
+              var classLocation = locator.LocateClass(discovered.FilePath, shortClassName);
               var classNode = new TestNode(
                       Id: classNodeId,
                       DisplayName: discovered.ClassName,

--- a/EasyDotnet.IDE/TestRunner/Service/TestRunnerService.cs
+++ b/EasyDotnet.IDE/TestRunner/Service/TestRunnerService.cs
@@ -689,11 +689,11 @@ public class TestRunnerService(
         {
           var type = n.Type switch
           {
-            NodeType.Namespace => "namespace",
-            NodeType.TestClass => "namespace",
+            NodeType.Namespace or
+            NodeType.TestClass or
             NodeType.TheoryGroup => "namespace",
-            NodeType.TestMethod => "test",
-            NodeType.Subcase => "test",
+            NodeType.TestMethod or
+            NodeType.Subcase or
             NodeType.ProbableTest => "test",
             _ => null
           };


### PR DESCRIPTION
- find range for classess with primary constructors
- don't mark test methods with non-theory arguments as theory group (example is `ClassDataSource` from `TUnit`)