### PR TITLE
fix(test-runner): handle generic constructor arguments

### DIFF
--- a/EasyDotnet.ContainerTests/TestRunner/Fixtures/TestFixtures.cs
+++ b/EasyDotnet.ContainerTests/TestRunner/Fixtures/TestFixtures.cs
@@ -381,6 +381,24 @@ public static class TestFixtures
     """;
 
   /// <summary>
+  /// TUnit test with injected dependency via primary constructor argument with [ClassDataSource]
+  /// </summary>
+  public const string TUnitPrimaryConstructorClass = """
+      namespace Sample.TUnitPrimaryConstructor
+      {
+          public class SomeValue();
+          public class LambdaFactory<T> where T : class { }
+
+          [ClassDataSource<LambdaFactory<SomeValue>>()]
+          public class SomeValueTests(LambdaFactory<SomeValue> factory)
+          {
+              [Test]
+              public async Task M() => await Task.CompletedTask;
+          }
+      }
+      """;
+
+  /// <summary>
   /// xUnit parameterised test using a dynamic member data source (<c>[MemberData]</c>).
   /// Adapters often route MemberData through a different code path than InlineData —
   /// the shape should still be TheoryGroup + N Subcases. Source shared between v2 and v3.

--- a/EasyDotnet.ContainerTests/TestRunner/TUnitMtpDiscoveryTests.cs
+++ b/EasyDotnet.ContainerTests/TestRunner/TUnitMtpDiscoveryTests.cs
@@ -115,6 +115,23 @@ public abstract class TUnitMtpDiscoveryTests<TContainer> : TestRunnerTestBase<TC
     Assert.Equal("custom test name", method.DisplayName);
   }
 
+  [Fact]
+  public async Task Discover_ClassWithPrimaryConstructorArgument_ProducesCorrectDisplayName()
+  {
+    const string expectedClassName = "SomeValueTests";
+
+    using var fixture = new TestProjectFixtureBuilder()
+      .WithName("Sample.TUnitPrimaryConstructor")
+      .WithFramework(TestFrameworkKind.TUnitMtp)
+      .WithFile("TUnitPrimaryConstructor.cs", TestFixtures.TUnitPrimaryConstructorClass)
+      .Build();
+
+    await InitializeTestRunnerAsync(fixture);
+
+    var testClass = Assert.Single(NodesOfType(NodeTypeNames.TestClass));
+    Assert.Equal(expectedClassName, testClass.DisplayName);
+  }
+
   private string DumpNodes() =>
     string.Join("\n", Nodes.Values
       .OrderBy(n => n.Id)

--- a/EasyDotnet.IDE/EasyDotnet.IDE.csproj
+++ b/EasyDotnet.IDE/EasyDotnet.IDE.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>3.4.14</Version>
+    <Version>3.4.15</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/EasyDotnet.IDE/TestRunner/Adapters/MtpExtensions.cs
+++ b/EasyDotnet.IDE/TestRunner/Adapters/MtpExtensions.cs
@@ -17,7 +17,12 @@ public static class MtpExtensions
     {
       // Standard MTP (TUnit, NUnit, MSTest v3)
       // TestType = "My.App.Tests.MyClass" → ns=["My","App","Tests"], class="MyClass"
-      var typeParts = node.TestType.Split('.');
+      // Generic constructor argument:
+      // TestType = "TUnit.Basic.SharedTest(TUnit.Basic.LambdaFactory\u00601[TUnit.Basic.SomeValue]).1.1.Calculator_ResultCanBeStoredV2.1.1.0" -> ns=["TUnit", "Basic"], class = "SharedTest"
+      var primaryConstructorStart = node.TestType.IndexOf('(');
+      var typeParts = primaryConstructorStart > 0
+        ? node.TestType[..primaryConstructorStart].Split('.')
+        : node.TestType.Split('.');
       className = typeParts[^1];
       namespaceParts = typeParts.Length > 1 ? typeParts[..^1] : [];
       rawLeaf = node.DisplayName;

--- a/EasyDotnet.IDE/TestRunner/Executor/OperationExecutor.cs
+++ b/EasyDotnet.IDE/TestRunner/Executor/OperationExecutor.cs
@@ -65,12 +65,7 @@ public class OperationExecutor(
             var classNodeId = NodeIdBuilder.Class(namespaceNodeId, discovered.ClassName);
             if (emittedClasses.Add(classNodeId))
             {
-              // Ignore potential primary constructor arguments
-              var shortClassName = discovered.ClassName.Contains('(')
-                ? discovered.ClassName[..(discovered.ClassName.IndexOf('('))]
-                : discovered.ClassName;
-
-              var classLocation = locator.LocateClass(discovered.FilePath, shortClassName);
+              var classLocation = locator.LocateClass(discovered.FilePath, discovered.ClassName);
               var classNode = new TestNode(
                       Id: classNodeId,
                       DisplayName: discovered.ClassName,


### PR DESCRIPTION
Given test class with primary constructor argument like this:

`TUnit.Basic.SharedTest(TUnit.Basic.LambdaFactory\u00601[TUnit.Basic.SomeValue]).1.1.Calculator_ResultCanBeStoredV2.1.1.0`

produces `SomeValue])` as test name which is due to splitting on dot, this fixes it so that constructor will be ignored