### PR TITLE
fix(new-file): use create file lsp edit to create new file

### DIFF
--- a/EasyDotnet.ContainerTests/NewFileCreateItemTests.cs
+++ b/EasyDotnet.ContainerTests/NewFileCreateItemTests.cs
@@ -203,11 +203,17 @@ public abstract class NewFileCreateItemTests<TContainer> : ContainerTestBase<TCo
     public Task<bool> ApplyWorkspaceEdit(WorkspaceEdit edit)
     {
       test._calls.Enqueue("applyWorkspaceEdit");
-      foreach (var change in edit.DocumentChanges)
+
+      foreach (var change in edit.DocumentChanges.Where(x => x.Kind == "create"))
       {
-        var path = new Uri(change.TextDocument.Uri).LocalPath;
+        var path = new Uri(change.Uri!).LocalPath;
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-        File.WriteAllText(path, change.Edits.Single().NewText);
+      }
+
+      foreach (var change in edit.DocumentChanges.Where(x => x.Edits is { Length: > 0 }))
+      {
+        var path = new Uri(change.TextDocument!.Uri).LocalPath;
+        File.WriteAllText(path, change.Edits!.Single().NewText);
       }
 
       return Task.FromResult(true);

--- a/EasyDotnet.IDE/EasyDotnet.IDE.csproj
+++ b/EasyDotnet.IDE/EasyDotnet.IDE.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>3.4.16</Version>
+    <Version>3.4.17</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/EasyDotnet.IDE/EasyDotnet.IDE.csproj
+++ b/EasyDotnet.IDE/EasyDotnet.IDE.csproj
@@ -6,7 +6,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-easydotnet</ToolCommandName>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>3.4.17</Version>
+    <Version>3.4.18</Version>
     <Authors>Gustav Eikaas</Authors>
     <PackageId>EasyDotnet</PackageId>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/EasyDotnet.IDE/Models/Client/WorkspaceEdit.cs
+++ b/EasyDotnet.IDE/Models/Client/WorkspaceEdit.cs
@@ -1,8 +1,31 @@
 namespace EasyDotnet.IDE.Models.Client;
 
-public record WorkspaceEdit(WorkspaceDocumentChange[] DocumentChanges);
+public record WorkspaceEdit(DocumentChange[] DocumentChanges);
 
-public record WorkspaceDocumentChange(TextDocumentIdentifier TextDocument, TextEdit[] Edits);
+// Kept with nullable properties to omit errors for container tests and deserialization
+// evaluate later with System.Text.Json and polymorphic support when needed 
+public record DocumentChange
+{
+  // CreateFile
+  public string? Uri { get; init; }
+  public string? Kind { get; init; }
+
+  // TextDocumentEdit
+  public TextDocumentIdentifier? TextDocument { get; init; }
+  public TextEdit[]? Edits { get; init; }
+
+  public static DocumentChange CreateFile(string uri) => new()
+  {
+    Kind = "create",
+    Uri = uri
+  };
+
+  public static DocumentChange TextDocumentEdit(string uri, TextEdit[] edits) => new()
+  {
+    TextDocument = new TextDocumentIdentifier(uri),
+    Edits = edits
+  };
+}
 
 public record TextDocumentIdentifier(string Uri);
 

--- a/EasyDotnet.IDE/NewFile/NewFileService.cs
+++ b/EasyDotnet.IDE/NewFile/NewFileService.cs
@@ -22,36 +22,7 @@ public class NewFileService(IBuildHostManager buildHostManager, IEditorService e
       return false;
     }
 
-    var (rootNamespace, langVersion, relativeDir) = await ResolveProjectContext(filePath, cancellationToken);
-
-    var supportsFileScopedNamespace =
-        string.IsNullOrEmpty(langVersion) ||
-        string.Compare(langVersion, "10.0", StringComparison.OrdinalIgnoreCase) >= 0 ||
-        langVersion.Equals("latest", StringComparison.OrdinalIgnoreCase);
-
-    var useFileScopedNs = preferFileScopedNamespace && supportsFileScopedNamespace;
-
-    var nsSuffix = relativeDir.Replace(Path.DirectorySeparatorChar, '.');
-    var fullNamespace = string.IsNullOrEmpty(nsSuffix) ? rootNamespace : $"{rootNamespace}.{nsSuffix}";
-
-    var className = Path.GetFileNameWithoutExtension(filePath).Split(".").ElementAt(0);
-    var typeDecl = CreateTypeDeclaration(kind, className);
-
-    BaseNamespaceDeclarationSyntax nsDeclaration = useFileScopedNs
-        ? SyntaxFactory.FileScopedNamespaceDeclaration(SyntaxFactory.ParseName(fullNamespace))
-              .AddMembers(typeDecl)
-        : SyntaxFactory.NamespaceDeclaration(SyntaxFactory.ParseName(fullNamespace))
-              .AddMembers(typeDecl);
-
-    var unit = SyntaxFactory.CompilationUnit()
-        .AddMembers(nsDeclaration)
-        .NormalizeWhitespace(eol: "\n");
-
-    if (preferFileScopedNamespace)
-    {
-      unit = unit.AddNewLinesAfterNamespaceDeclaration();
-    }
-
+    var unit = await GenerateContentAsync(filePath, kind, preferFileScopedNamespace, cancellationToken);
     return await editorService.ApplyWorkspaceEdit(BuildEdit(filePath, unit.ToFullString()));
   }
 
@@ -107,14 +78,15 @@ public class NewFileService(IBuildHostManager buildHostManager, IEditorService e
       return;
     }
 
-    var success = await BootstrapFile(filePath, selection.Kind, preferFileScopedNamespace, cancellationToken);
-    if (success)
+    try
     {
+      var content = await GenerateContentAsync(filePath, selection.Kind, preferFileScopedNamespace, cancellationToken);
+      await editorService.ApplyWorkspaceEdit(BuildEdit(filePath, content.ToFullString(), createFile: true));
       await editorService.RequestOpenBuffer(filePath);
     }
-    else
+    catch (Exception ex)
     {
-      await editorService.DisplayError("Failed to create new file");
+      await editorService.DisplayError($"Failed to create new file: {ex.Message} {ex.StackTrace}");
     }
   }
 
@@ -154,6 +126,41 @@ public class NewFileService(IBuildHostManager buildHostManager, IEditorService e
     return true;
   }
 
+  private async Task<CompilationUnitSyntax> GenerateContentAsync(string filePath, Kind kind, bool preferFileScopedNamespace, CancellationToken cancellationToken)
+  {
+    var (rootNamespace, langVersion, relativeDir) = await ResolveProjectContext(filePath, cancellationToken);
+
+    var supportsFileScopedNamespace =
+        string.IsNullOrEmpty(langVersion) ||
+        string.Compare(langVersion, "10.0", StringComparison.OrdinalIgnoreCase) >= 0 ||
+        langVersion.Equals("latest", StringComparison.OrdinalIgnoreCase);
+
+    var useFileScopedNs = preferFileScopedNamespace && supportsFileScopedNamespace;
+
+    var nsSuffix = relativeDir.Replace(Path.DirectorySeparatorChar, '.');
+    var fullNamespace = string.IsNullOrEmpty(nsSuffix) ? rootNamespace : $"{rootNamespace}.{nsSuffix}";
+
+    var className = Path.GetFileNameWithoutExtension(filePath).Split(".").ElementAt(0);
+    var typeDecl = CreateTypeDeclaration(kind, className);
+
+    BaseNamespaceDeclarationSyntax nsDeclaration = useFileScopedNs
+        ? SyntaxFactory.FileScopedNamespaceDeclaration(SyntaxFactory.ParseName(fullNamespace))
+              .AddMembers(typeDecl)
+        : SyntaxFactory.NamespaceDeclaration(SyntaxFactory.ParseName(fullNamespace))
+              .AddMembers(typeDecl);
+
+    var unit = SyntaxFactory.CompilationUnit()
+        .AddMembers(nsDeclaration)
+        .NormalizeWhitespace(eol: "\n");
+
+    if (preferFileScopedNamespace)
+    {
+      unit = unit.AddNewLinesAfterNamespaceDeclaration();
+    }
+
+    return unit;
+  }
+
   private async Task<(string rootNamespace, string? langVersion, string relativeDir)> ResolveProjectContext(string filePath, CancellationToken cancellationToken)
   {
     var projectPath = FindCsprojFromFile(filePath);
@@ -177,13 +184,19 @@ public class NewFileService(IBuildHostManager buildHostManager, IEditorService e
     return (Path.GetFileNameWithoutExtension(filePath).Split(".").First(), null, string.Empty);
   }
 
-  private static WorkspaceEdit BuildEdit(string filePath, string content) =>
-    new([
-      new WorkspaceDocumentChange(
-        new TextDocumentIdentifier($"file://{filePath}"),
-        [new TextEdit(new TextEditRange(new TextEditPosition(0, 0), new TextEditPosition(0, 0)), content)]
-      )
-    ]);
+  private static WorkspaceEdit BuildEdit(string filePath, string content, bool createFile = false)
+  {
+    var uri = $"file://{filePath}";
+    var textDocumentChange = DocumentChange.TextDocumentEdit(uri, [new TextEdit(new TextEditRange(new TextEditPosition(0, 0), new TextEditPosition(0, 0)), content)]);
+
+    if (!createFile)
+    {
+      return new([textDocumentChange]);
+    }
+
+    var createFileChange = DocumentChange.CreateFile(uri);
+    return new([createFileChange, textDocumentChange]);
+  }
 
   private static string? FindCsprojFromFile(string filePath)
   {


### PR DESCRIPTION
Use `CreateFile` lsp edit to instruct neovim to create new file to properly attach lsp to it right after creation