### PR TITLE
feat(debugger): derive source path mappings from MSBuild PathMap

### DIFF
--- a/EasyDotnet.BuildServer.Contracts/MsBuildPropertyCatalog.cs
+++ b/EasyDotnet.BuildServer.Contracts/MsBuildPropertyCatalog.cs
@@ -19,7 +19,8 @@ public static class MsBuildPropertyCatalog
     ["IsPackable"] = "Indicates whether the project can be packed into a NuGet package.",
     ["PackageId"] = "Specifies the NuGet package identifier.",
     ["Version"] = "Specifies the project or package version.",
-    ["UserSecretsId"] = "Specifies the user secrets identifier for the project."
+    ["UserSecretsId"] = "Specifies the user secrets identifier for the project.",
+    ["PathMap"] = "Maps physical source paths to source paths written to compiler output and debug information."
   };
 
   public static IEnumerable<string> GetAllPropertyNames() => GetAllPropertiesWithDocs().Select(p => p.Name);

--- a/EasyDotnet.BuildServer.Contracts/ProjectPropertiesContracts.cs
+++ b/EasyDotnet.BuildServer.Contracts/ProjectPropertiesContracts.cs
@@ -162,7 +162,8 @@ public record DotnetProject
     string? MSBuildProjectExtensionsPath,
     bool SelfContained,
     string? UserProfileRuntimeStorePath,
-    string? TargetPlatformIdentifier
+    string? TargetPlatformIdentifier,
+    string? PathMap
 );
 
 public sealed record ValidatedDotnetProject

--- a/EasyDotnet.BuildServer.SmokeTests/BuildServerSmokeTests.cs
+++ b/EasyDotnet.BuildServer.SmokeTests/BuildServerSmokeTests.cs
@@ -65,9 +65,11 @@ public sealed class BuildServerSmokeTests
     await using var srv = await BuildServerProcess.StartAsync(exe, leadingArgs, TimeSpan.FromSeconds(30));
 
     var fixture = Path.Combine(AppContext.BaseDirectory, "Fixtures", "Minimal", "Minimal.csproj");
+    var inheritedFixture = Path.Combine(AppContext.BaseDirectory, "Fixtures", "Minimal", "Inherited.csproj");
     Assert.True(File.Exists(fixture), $"fixture not found: {fixture}");
+    Assert.True(File.Exists(inheritedFixture), $"fixture not found: {inheritedFixture}");
 
-    var request = new GetProjectPropertiesBatchRequest([fixture], "Debug");
+    var request = new GetProjectPropertiesBatchRequest([fixture, inheritedFixture], Configuration: null);
 
     var stream = await srv.Rpc.InvokeWithParameterObjectAsync<IAsyncEnumerable<ProjectEvaluationResult>>(
         "project/get-properties-batch",
@@ -81,5 +83,9 @@ public sealed class BuildServerSmokeTests
 
     Assert.NotEmpty(results);
     Assert.All(results, r => Assert.Null(r.Error));
+    Assert.Contains(results, result => result.Project?.ProjectName == "Minimal"
+        && result.Project.Raw.PathMap == $"{Path.GetDirectoryName(fixture)}=overridden/Minimal");
+    Assert.Contains(results, result => result.Project?.ProjectName == "Inherited"
+        && result.Project.Raw.PathMap == $"{Path.GetDirectoryName(inheritedFixture)}=imported/Inherited");
   }
 }

--- a/EasyDotnet.BuildServer.SmokeTests/Fixtures/Minimal/Directory.Build.props
+++ b/EasyDotnet.BuildServer.SmokeTests/Fixtures/Minimal/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <PathMap>$(MSBuildProjectDirectory)=imported/$(MSBuildProjectName)</PathMap>
+  </PropertyGroup>
+</Project>

--- a/EasyDotnet.BuildServer.SmokeTests/Fixtures/Minimal/Inherited.csproj
+++ b/EasyDotnet.BuildServer.SmokeTests/Fixtures/Minimal/Inherited.csproj
@@ -2,7 +2,5 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <EnableFastUpToDateCheck>true</EnableFastUpToDateCheck>
-    <PathMap>$(MSBuildProjectDirectory)=overridden/$(MSBuildProjectName)</PathMap>
   </PropertyGroup>
 </Project>

--- a/EasyDotnet.BuildServer.SmokeTests/PropertyCache/PropertyCacheTestBase.cs
+++ b/EasyDotnet.BuildServer.SmokeTests/PropertyCache/PropertyCacheTestBase.cs
@@ -50,7 +50,7 @@ internal sealed class PropertyCacheHarness : IAsyncDisposable
   public async Task<PropertyCacheDiagnosticsResponse> GetStatsAsync()
       => await Server.Rpc.InvokeAsync<PropertyCacheDiagnosticsResponse>("diagnostics/property-cache");
 
-  public async Task<List<ProjectEvaluationResult>> EvaluateAsync(string projectPath, string configuration = "Debug", string? platform = null)
+  public async Task<List<ProjectEvaluationResult>> EvaluateAsync(string projectPath, string? configuration = "Debug", string? platform = null)
   {
     var request = new GetProjectPropertiesBatchRequest([projectPath], configuration, platform);
     var stream = await Server.Rpc.InvokeWithParameterObjectAsync<IAsyncEnumerable<ProjectEvaluationResult>>(

--- a/EasyDotnet.BuildServer.SmokeTests/PropertyCache/PropertyCacheTests.cs
+++ b/EasyDotnet.BuildServer.SmokeTests/PropertyCache/PropertyCacheTests.cs
@@ -1,5 +1,6 @@
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json.Nodes;
 using EasyDotnet.BuildServer.Contracts;
 
 namespace EasyDotnet.BuildServer.SmokeTests.PropertyCache;
@@ -276,6 +277,39 @@ public sealed class PropertyCacheTests
 
     var stats = await h.GetStatsAsync();
     Assert.Equal(1, stats.Evaluations);
+  }
+
+  [Theory]
+  [MemberData(nameof(Targets))]
+  public async Task Cache_From_Previous_Property_Catalog_Is_Ignored_For_Null_Configuration(
+      string tfm,
+      string exe,
+      string[] leadingArgs)
+  {
+    _ = tfm;
+    await using var h = await PropertyCacheHarness.StartAsync(exe, leadingArgs);
+    var csproj = h.CreateSingleTfmProject();
+    var projectDir = Path.GetDirectoryName(csproj)!;
+    File.WriteAllText(
+        Path.Combine(projectDir, "Directory.Build.props"),
+        "<Project><PropertyGroup><PathMap>$(MSBuildProjectDirectory)=imported/$(MSBuildProjectName)</PathMap></PropertyGroup></Project>");
+
+    var initial = await h.EvaluateAsync(csproj, configuration: null);
+    Assert.Equal($"{projectDir}=imported/App", initial[0].Project!.Raw.PathMap);
+
+    var cacheFile = Assert.Single(Directory.GetFiles(h.CacheDir));
+    var cached = JsonNode.Parse(File.ReadAllText(cacheFile))!.AsObject();
+    cached["SchemaVersion"] = 2;
+    cached["Properties"]!.AsObject().Remove("PathMap");
+    File.WriteAllText(cacheFile, cached.ToJsonString());
+
+    await h.RestartServerAsync();
+    var result = await h.EvaluateAsync(csproj, configuration: null);
+
+    Assert.Equal($"{projectDir}=imported/App", result[0].Project!.Raw.PathMap);
+    var stats = await h.GetStatsAsync();
+    Assert.Equal(1, stats.Evaluations);
+    Assert.Equal(0, stats.DiskHits);
   }
 
   private static string ComputeDiskFileName(string projectFullPath, string configuration, string? platform, string targetFramework, string msBuildVersion)

--- a/EasyDotnet.BuildServer/MsBuildProject/Cache/PropertyCacheEntry.cs
+++ b/EasyDotnet.BuildServer/MsBuildProject/Cache/PropertyCacheEntry.cs
@@ -16,5 +16,5 @@ public sealed record PropertyCacheEntry(
     List<InvalidationGlobEntry> InvalidationGlobs,
     long CreatedAtTicks)
 {
-  public const int CurrentSchemaVersion = 2;
+  public const int CurrentSchemaVersion = 3;
 }

--- a/EasyDotnet.BuildServer/MsBuildProject/DotnetProjectDeserializer.cs
+++ b/EasyDotnet.BuildServer/MsBuildProject/DotnetProjectDeserializer.cs
@@ -155,6 +155,7 @@ public static class DotnetProjectDeserializer
         MSBuildProjectExtensionsPath: bag.Get(MsBuildProperties.MSBuildProjectExtensionsPath),
         SelfContained: bag.Get(MsBuildProperties.SelfContained),
         UserProfileRuntimeStorePath: bag.Get(MsBuildProperties.UserProfileRuntimeStorePath),
-        TargetPlatformIdentifier: bag.Get(MsBuildProperties.TargetPlatformIdentifier)
+        TargetPlatformIdentifier: bag.Get(MsBuildProperties.TargetPlatformIdentifier),
+        PathMap: bag.Get(MsBuildProperties.PathMap)
       );
 }

--- a/EasyDotnet.BuildServer/MsBuildProject/MsBuildProperties.cs
+++ b/EasyDotnet.BuildServer/MsBuildProject/MsBuildProperties.cs
@@ -523,6 +523,13 @@ public static class MsBuildProperties
           Deserialize: MsBuildValueParsers.AsString
       );
 
+  public static readonly MsBuildProperty<string?> PathMap =
+      new(
+          Name: "PathMap",
+          Description: "Maps physical source paths to source paths written to compiler output and debug information.",
+          Deserialize: MsBuildValueParsers.AsString
+      );
+
   public static readonly MsBuildProperty<string?> RestoreProjectStyle =
       new(
           Name: "RestoreProjectStyle",

--- a/EasyDotnet.Debugger.Tests/Dap/ClientMessageInterceptorTests.cs
+++ b/EasyDotnet.Debugger.Tests/Dap/ClientMessageInterceptorTests.cs
@@ -31,14 +31,7 @@ public class ClientMessageInterceptorTests
       }, SerializerOptions)
     });
 
-    var interceptor = new ClientMessageInterceptor(
-      NullLogger<ClientMessageInterceptor>.Instance,
-      new ValueConverterService(
-        NullLogger<ValueConverterService>.Instance,
-        NullLoggerFactory.Instance),
-      request => Task.FromResult(request),
-      _ => { },
-      () => { });
+    var interceptor = CreateInterceptor();
 
     var request = new Request
     {
@@ -67,13 +60,213 @@ public class ClientMessageInterceptorTests
     await Assert.That(response.Body!.Value.GetProperty("variablesReference").GetInt32()).IsEqualTo(0);
   }
 
-  private sealed class FakeDebuggerProxy(Response internalResponse) : IDebuggerProxy
+  [Test]
+  public async Task AttachRequestIsDeserializedAndRewritten()
+  {
+    var rewriterCalled = false;
+    var interceptor = CreateInterceptor(attachRequestRewriter: request =>
+    {
+      rewriterCalled = true;
+      request.Arguments.Cwd = "/rewritten";
+      return Task.FromResult(request);
+    });
+    var request = DapMessageDeserializer.Parse("""
+      {
+        "seq": 1,
+        "type": "request",
+        "command": "attach",
+        "arguments": {
+          "processId": 123,
+          "customOption": true
+        }
+      }
+      """);
+
+    var result = await interceptor.InterceptAsync(request, new FakeDebuggerProxy(), CancellationToken.None);
+
+    await Assert.That(rewriterCalled).IsTrue();
+    await Assert.That(result).IsTypeOf<InterceptableAttachRequest>();
+    var attachRequest = (InterceptableAttachRequest)result!;
+    await Assert.That(attachRequest.Arguments.ProcessId).IsEqualTo(123);
+    await Assert.That(attachRequest.Arguments.Cwd).IsEqualTo("/rewritten");
+    await Assert.That(attachRequest.Arguments.Other["customOption"].GetBoolean()).IsTrue();
+  }
+
+  [Test]
+  public async Task ConfiguredSourcePathMapIsAppliedToSourceBearingGenericRequests()
+  {
+    var mapper = new SourcePathMapper();
+    mapper.Configure(new Dictionary<string, string> { ["Modeler"] = "/work/modeler" });
+    var interceptor = CreateInterceptor(mapper);
+    var request = new Request
+    {
+      Seq = 2,
+      Type = "request",
+      Command = "breakpointLocations",
+      Arguments = JsonSerializer.SerializeToElement(new
+      {
+        source = new { name = "Program.cs", path = "/work/modeler/Program.cs" },
+        line = 10,
+        metadata = new { path = "/work/modeler/metadata.json" }
+      })
+    };
+
+    var result = (Request)(await interceptor.InterceptAsync(request, new FakeDebuggerProxy(), CancellationToken.None))!;
+
+    var arguments = result.Arguments!.Value;
+    await Assert.That(arguments.GetProperty("source").GetProperty("path").GetString())
+      .IsEqualTo("Modeler/Program.cs");
+    await Assert.That(arguments.GetProperty("metadata").GetProperty("path").GetString())
+      .IsEqualTo("/work/modeler/metadata.json");
+  }
+
+  [Test]
+  public async Task EvaluateRequestMapsAdapterExtensionSourceBeforeSpecializedHandling()
+  {
+    var mapper = new SourcePathMapper();
+    mapper.Configure(new Dictionary<string, string> { ["Modeler"] = "/work/modeler" });
+    var interceptor = CreateInterceptor(mapper);
+    var request = new Request
+    {
+      Seq = 2,
+      Type = "request",
+      Command = "evaluate",
+      Arguments = JsonSerializer.SerializeToElement(new
+      {
+        expression = "value",
+        context = "repl",
+        source = new { path = "/work/modeler/Program.cs" }
+      })
+    };
+
+    var result = (Request)(await interceptor.InterceptAsync(request, new FakeDebuggerProxy(), CancellationToken.None))!;
+
+    await Assert.That(result.Arguments!.Value.GetProperty("source").GetProperty("path").GetString())
+      .IsEqualTo("Modeler/Program.cs");
+  }
+
+  [Test]
+  public async Task MinimalSetBreakpointsRequestMapsSourcePath()
+  {
+    var mapper = new SourcePathMapper();
+    mapper.Configure(new Dictionary<string, string> { ["Modeler"] = "/work/modeler" });
+    var interceptor = CreateInterceptor(mapper);
+    var request = DapMessageDeserializer.Parse("""
+      {
+        "seq": 2,
+        "type": "request",
+        "command": "setBreakpoints",
+        "arguments": {
+          "source": {
+            "path": "/work/modeler/Program.cs"
+          }
+        }
+      }
+      """);
+
+    var result = (SetBreakpointsRequest)(await interceptor.InterceptAsync(request, new FakeDebuggerProxy(), CancellationToken.None))!;
+
+    await Assert.That(result.Arguments.Source.Path).IsEqualTo("Modeler/Program.cs");
+    await Assert.That(result.Arguments.Breakpoints).IsNull();
+    await Assert.That(result.Arguments.Lines).IsNull();
+    await Assert.That(result.Arguments.SourceModified).IsNull();
+  }
+
+  [Test]
+  public async Task SourceReferenceOnlySetBreakpointsRequestPreservesUnknownSourceFields()
+  {
+    var interceptor = CreateInterceptor(new SourcePathMapper());
+    var request = DapMessageDeserializer.Parse("""
+      {
+        "seq": 2,
+        "type": "request",
+        "command": "setBreakpoints",
+        "arguments": {
+          "source": {
+            "sourceReference": 42,
+            "adapterData": {
+              "documentId": "generated"
+            }
+          }
+        }
+      }
+      """);
+
+    var result = (SetBreakpointsRequest)(await interceptor.InterceptAsync(request, new FakeDebuggerProxy(), CancellationToken.None))!;
+    var serialized = JsonSerializer.SerializeToElement(result, result.GetType(), SerializerOptions);
+    var source = serialized.GetProperty("arguments").GetProperty("source");
+
+    await Assert.That(result.Arguments.Source.Path).IsNull();
+    await Assert.That(source.GetProperty("sourceReference").GetInt32()).IsEqualTo(42);
+    await Assert.That(source.GetProperty("adapterData").GetProperty("documentId").GetString()).IsEqualTo("generated");
+  }
+
+  [Test]
+  public async Task SetBreakpointsRequestMapsOfficialSourceTreeAndPreservesAdapterData()
+  {
+    var mapper = new SourcePathMapper();
+    mapper.Configure(new Dictionary<string, string> { ["Modeler"] = "/work/modeler" });
+    var interceptor = CreateInterceptor(mapper);
+    var request = DapMessageDeserializer.Parse("""
+      {
+        "seq": 2,
+        "type": "request",
+        "command": "setBreakpoints",
+        "arguments": {
+          "source": {
+            "path": "/work/modeler/Program.cs",
+            "sources": [
+              {
+                "path": "/work/modeler/Generated.cs",
+                "adapterData": {
+                  "source": {
+                    "path": "/work/modeler/nested-opaque.cs"
+                  }
+                }
+              }
+            ],
+            "adapterData": {
+              "source": {
+                "path": "/work/modeler/opaque.cs"
+              }
+            }
+          }
+        }
+      }
+      """);
+
+    var result = (SetBreakpointsRequest)(await interceptor.InterceptAsync(request, new FakeDebuggerProxy(), CancellationToken.None))!;
+    var serialized = JsonSerializer.SerializeToElement(result, result.GetType(), SerializerOptions);
+    var source = serialized.GetProperty("arguments").GetProperty("source");
+
+    await Assert.That(source.GetProperty("path").GetString()).IsEqualTo("Modeler/Program.cs");
+    await Assert.That(source.GetProperty("sources")[0].GetProperty("path").GetString())
+      .IsEqualTo("Modeler/Generated.cs");
+    await Assert.That(source.GetProperty("adapterData").GetProperty("source").GetProperty("path").GetString())
+      .IsEqualTo("/work/modeler/opaque.cs");
+    await Assert.That(source.GetProperty("sources")[0].GetProperty("adapterData").GetProperty("source").GetProperty("path").GetString())
+      .IsEqualTo("/work/modeler/nested-opaque.cs");
+  }
+
+  private static ClientMessageInterceptor CreateInterceptor(
+    SourcePathMapper? sourcePathMapper = null,
+    Func<InterceptableAttachRequest, Task<InterceptableAttachRequest>>? attachRequestRewriter = null) => new(
+    NullLogger<ClientMessageInterceptor>.Instance,
+    new ValueConverterService(
+      NullLogger<ValueConverterService>.Instance,
+      NullLoggerFactory.Instance),
+    attachRequestRewriter ?? (request => Task.FromResult(request)),
+    _ => { },
+    () => { },
+    sourcePathMapper: sourcePathMapper);
+
+  private sealed class FakeDebuggerProxy(Response? internalResponse = null) : IDebuggerProxy
   {
     public ProtocolMessage? ClientMessage { get; private set; }
     public Task Completion => Task.CompletedTask;
 
     public Task<Response> RunInternalRequestAsync(Request request, CancellationToken cancellationToken)
-      => Task.FromResult(internalResponse);
+      => Task.FromResult(internalResponse ?? throw new InvalidOperationException("No internal response was configured."));
 
     public Task<Response> RunClientRequestAsync(Request request, CancellationToken cancellationToken)
       => throw new NotImplementedException();

--- a/EasyDotnet.Debugger.Tests/Dap/DebuggerMessageInterceptorTests.cs
+++ b/EasyDotnet.Debugger.Tests/Dap/DebuggerMessageInterceptorTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using EasyDotnet.Debugger.Messages;
 using EasyDotnet.Debugger.Services;
 using EasyDotnet.Debugger.Session;
@@ -111,10 +112,244 @@ public class DebuggerMessageInterceptorTests
     await Assert.That(startSignals).Contains("process event");
   }
 
+  [Test]
+  public async Task StackTraceResponseMapsSourcePathsWithoutChangingOtherPaths()
+  {
+    var mapper = CreateMapper();
+    var interceptor = CreateInterceptor(_ => { }, () => { }, (_, _) => { }, mapper);
+    var response = new Response
+    {
+      Seq = 10,
+      Type = "response",
+      RequestSeq = 1,
+      Success = true,
+      Command = "stackTrace",
+      Body = JsonSerializer.SerializeToElement(new
+      {
+        stackFrames = new[]
+        {
+          new
+          {
+            id = 1,
+            source = new { name = "Program.cs", path = "Modeler/Program.cs" },
+            line = 10
+          }
+        },
+        metadata = new { path = "Modeler/metadata.json" }
+      })
+    };
+
+    var result = (Response)(await interceptor.InterceptAsync(response, new FakeDebuggerProxy(), CancellationToken.None))!;
+
+    var body = result.Body!.Value;
+    await Assert.That(body.GetProperty("stackFrames")[0].GetProperty("source").GetProperty("path").GetString())
+      .IsEqualTo("/work/modeler/Program.cs");
+    await Assert.That(body.GetProperty("metadata").GetProperty("path").GetString())
+      .IsEqualTo("Modeler/metadata.json");
+  }
+
+  [Test]
+  public async Task SetBreakpointsResponseMapsBreakpointSourcePath()
+  {
+    var interceptor = CreateInterceptor(_ => { }, () => { }, (_, _) => { }, CreateMapper());
+    var response = new Response
+    {
+      Seq = 10,
+      Type = "response",
+      RequestSeq = 1,
+      Success = true,
+      Command = "setBreakpoints",
+      Body = JsonSerializer.SerializeToElement(new
+      {
+        breakpoints = new[]
+        {
+          new { verified = true, source = new { name = "Program.cs", path = "Modeler/Program.cs" }, line = 10 }
+        }
+      })
+    };
+
+    var result = (Response)(await interceptor.InterceptAsync(response, new FakeDebuggerProxy(), CancellationToken.None))!;
+
+    await Assert.That(result.Body!.Value.GetProperty("breakpoints")[0].GetProperty("source").GetProperty("path").GetString())
+      .IsEqualTo("/work/modeler/Program.cs");
+  }
+
+  [Test]
+  public async Task BreakpointEventMapsBreakpointSourcePath()
+  {
+    var interceptor = CreateInterceptor(_ => { }, () => { }, (_, _) => { }, CreateMapper());
+    var evt = new Event
+    {
+      Seq = 10,
+      Type = "event",
+      EventName = "breakpoint",
+      Body = JsonSerializer.SerializeToElement(new
+      {
+        reason = "changed",
+        breakpoint = new { verified = true, source = new { name = "Program.cs", path = "Modeler/Program.cs" }, line = 10 }
+      })
+    };
+
+    var result = (Event)(await interceptor.InterceptAsync(evt, new FakeDebuggerProxy(), CancellationToken.None))!;
+
+    await Assert.That(result.Body!.Value.GetProperty("breakpoint").GetProperty("source").GetProperty("path").GetString())
+      .IsEqualTo("/work/modeler/Program.cs");
+  }
+
+  [Test]
+  public async Task LoadedSourcesResponseMapsDirectSourceArrayPaths()
+  {
+    var interceptor = CreateInterceptor(_ => { }, () => { }, (_, _) => { }, CreateMapper());
+    var response = new Response
+    {
+      Seq = 10,
+      Type = "response",
+      RequestSeq = 1,
+      Success = true,
+      Command = "loadedSources",
+      Body = JsonSerializer.SerializeToElement(new
+      {
+        sources = new[] { new { name = "Program.cs", path = "Modeler/Program.cs" } }
+      })
+    };
+
+    var result = (Response)(await interceptor.InterceptAsync(response, new FakeDebuggerProxy(), CancellationToken.None))!;
+
+    await Assert.That(result.Body!.Value.GetProperty("sources")[0].GetProperty("path").GetString())
+      .IsEqualTo("/work/modeler/Program.cs");
+  }
+
+  [Test]
+  public async Task OutputEventDoesNotMapSourcePathsInsideOpaqueData()
+  {
+    var interceptor = CreateInterceptor(_ => { }, () => { }, (_, _) => { }, CreateMapper());
+    var evt = new Event
+    {
+      Seq = 10,
+      Type = "event",
+      EventName = "output",
+      Body = JsonSerializer.SerializeToElement(new
+      {
+        output = "diagnostic",
+        source = new { name = "Program.cs", path = "Modeler/Program.cs" },
+        data = new
+        {
+          source = new { path = "Modeler/opaque.cs" }
+        }
+      })
+    };
+
+    var result = (Event)(await interceptor.InterceptAsync(evt, new FakeDebuggerProxy(), CancellationToken.None))!;
+    var body = result.Body!.Value;
+
+    await Assert.That(body.GetProperty("source").GetProperty("path").GetString())
+      .IsEqualTo("/work/modeler/Program.cs");
+    await Assert.That(body.GetProperty("data").GetProperty("source").GetProperty("path").GetString())
+      .IsEqualTo("Modeler/opaque.cs");
+  }
+
+  [Test]
+  public async Task SourceAdapterDataRemainsOpaque()
+  {
+    var interceptor = CreateInterceptor(_ => { }, () => { }, (_, _) => { }, CreateMapper());
+    var evt = new Event
+    {
+      Seq = 10,
+      Type = "event",
+      EventName = "loadedSource",
+      Body = JsonSerializer.SerializeToElement(new
+      {
+        reason = "new",
+        source = new
+        {
+          path = "Modeler/Program.cs",
+          adapterData = new
+          {
+            source = new { path = "Modeler/opaque.cs" }
+          }
+        }
+      })
+    };
+
+    var result = (Event)(await interceptor.InterceptAsync(evt, new FakeDebuggerProxy(), CancellationToken.None))!;
+    var source = result.Body!.Value.GetProperty("source");
+
+    await Assert.That(source.GetProperty("path").GetString()).IsEqualTo("/work/modeler/Program.cs");
+    await Assert.That(source.GetProperty("adapterData").GetProperty("source").GetProperty("path").GetString())
+      .IsEqualTo("Modeler/opaque.cs");
+  }
+
+  [Test]
+  public async Task NestedOfficialSourcesAreMapped()
+  {
+    var interceptor = CreateInterceptor(_ => { }, () => { }, (_, _) => { }, CreateMapper());
+    var evt = new Event
+    {
+      Seq = 10,
+      Type = "event",
+      EventName = "loadedSource",
+      Body = JsonSerializer.SerializeToElement(new
+      {
+        reason = "new",
+        source = new
+        {
+          path = "Modeler/Program.cs",
+          sources = new[] { new { path = "Modeler/Generated.cs" } }
+        }
+      })
+    };
+
+    var result = (Event)(await interceptor.InterceptAsync(evt, new FakeDebuggerProxy(), CancellationToken.None))!;
+    var source = result.Body!.Value.GetProperty("source");
+
+    await Assert.That(source.GetProperty("path").GetString()).IsEqualTo("/work/modeler/Program.cs");
+    await Assert.That(source.GetProperty("sources")[0].GetProperty("path").GetString())
+      .IsEqualTo("/work/modeler/Generated.cs");
+  }
+
+  [Test]
+  public async Task DisassembleResponseMapsInstructionLocationsOnly()
+  {
+    var interceptor = CreateInterceptor(_ => { }, () => { }, (_, _) => { }, CreateMapper());
+    var response = new Response
+    {
+      Seq = 10,
+      Type = "response",
+      RequestSeq = 1,
+      Success = true,
+      Command = "disassemble",
+      Body = JsonSerializer.SerializeToElement(new
+      {
+        instructions = new[]
+        {
+          new
+          {
+            address = "0x1",
+            instruction = "nop",
+            location = new { path = "Modeler/Program.cs" }
+          }
+        },
+        metadata = new
+        {
+          location = new { path = "Modeler/opaque.cs" }
+        }
+      })
+    };
+
+    var result = (Response)(await interceptor.InterceptAsync(response, new FakeDebuggerProxy(), CancellationToken.None))!;
+    var body = result.Body!.Value;
+
+    await Assert.That(body.GetProperty("instructions")[0].GetProperty("location").GetProperty("path").GetString())
+      .IsEqualTo("/work/modeler/Program.cs");
+    await Assert.That(body.GetProperty("metadata").GetProperty("location").GetProperty("path").GetString())
+      .IsEqualTo("Modeler/opaque.cs");
+  }
+
   private static DebuggerMessageInterceptor CreateInterceptor(
     Action<string> onDebugStartSignal,
     Action onDebuggerConfigurationDone,
-    Action<string, string?> onDebugSessionStartFailed) =>
+    Action<string, string?> onDebugSessionStartFailed,
+    SourcePathMapper? sourcePathMapper = null) =>
     new(
       NullLogger<DebuggerMessageInterceptor>.Instance,
       new ValueConverterService(
@@ -124,7 +359,15 @@ public class DebuggerMessageInterceptorTests
       _ => { },
       onDebugStartSignal,
       onDebuggerConfigurationDone,
-      onDebugSessionStartFailed);
+      onDebugSessionStartFailed,
+      sourcePathMapper: sourcePathMapper);
+
+  private static SourcePathMapper CreateMapper()
+  {
+    var mapper = new SourcePathMapper();
+    mapper.Configure(new Dictionary<string, string> { ["Modeler"] = "/work/modeler" });
+    return mapper;
+  }
 
   private sealed class FakeDebuggerProxy : IDebuggerProxy
   {

--- a/EasyDotnet.Debugger.Tests/Dap/SourcePathMapperTests.cs
+++ b/EasyDotnet.Debugger.Tests/Dap/SourcePathMapperTests.cs
@@ -1,0 +1,183 @@
+using EasyDotnet.Debugger.Services;
+
+namespace EasyDotnet.Debugger.Tests.Dap;
+
+public class SourcePathMapperTests
+{
+  [Test]
+  public async Task MapDebuggerToClientMapsSourceBelowConfiguredPrefix()
+  {
+    var mapper = new SourcePathMapper();
+    mapper.Configure(new Dictionary<string, string>
+    {
+      ["Modeler"] = "/work/modeler"
+    });
+
+    var result = mapper.MapDebuggerToClient("Modeler/Program.cs");
+
+    await Assert.That(result).IsEqualTo("/work/modeler/Program.cs");
+  }
+
+  [Test]
+  public async Task MapClientToDebuggerMapsSourceBelowConfiguredPrefix()
+  {
+    var mapper = CreateMapper(("Modeler", "/work/modeler"));
+
+    var result = mapper.MapClientToDebugger("/work/modeler/Program.cs");
+
+    await Assert.That(result).IsEqualTo("Modeler/Program.cs");
+  }
+
+  [Test]
+  public async Task MapDebuggerToClientMapsExactPrefix()
+  {
+    var mapper = CreateMapper(("Modeler/", "/work/modeler/"));
+
+    var clientPath = mapper.MapDebuggerToClient("Modeler");
+    var debuggerPath = mapper.MapClientToDebugger("/work/modeler");
+
+    await Assert.That(clientPath).IsEqualTo("/work/modeler");
+    await Assert.That(debuggerPath).IsEqualTo("Modeler");
+  }
+
+  [Test]
+  public async Task MappingRequiresPathComponentBoundary()
+  {
+    var mapper = CreateMapper(("Project", "/work/Project"));
+
+    var debuggerPath = mapper.MapDebuggerToClient("Project.Other/Program.cs");
+    var clientPath = mapper.MapClientToDebugger("/work/Project.Other/Program.cs");
+
+    await Assert.That(debuggerPath).IsEqualTo("Project.Other/Program.cs");
+    await Assert.That(clientPath).IsEqualTo("/work/Project.Other/Program.cs");
+  }
+
+  [Test]
+  public async Task MappingUsesLongestPrefixInBothDirections()
+  {
+    var mapper = CreateMapper(
+      ("src", "/work"),
+      ("src/Project", "/work/Project"));
+
+    var clientPath = mapper.MapDebuggerToClient("src/Project/Program.cs");
+    var debuggerPath = mapper.MapClientToDebugger("/work/Project/Program.cs");
+
+    await Assert.That(clientPath).IsEqualTo("/work/Project/Program.cs");
+    await Assert.That(debuggerPath).IsEqualTo("src/Project/Program.cs");
+  }
+
+  [Test]
+  public async Task MappingMatchesEitherSeparatorAndUsesDestinationStyle()
+  {
+    var mapper = CreateMapper((@"Modeler\Generated", @"C:\work\Modeler"));
+
+    var clientPath = mapper.MapDebuggerToClient("Modeler/Generated/Program.cs");
+    var debuggerPath = mapper.MapClientToDebugger("C:/work/Modeler/Program.cs");
+
+    await Assert.That(clientPath).IsEqualTo(@"C:\work\Modeler\Program.cs");
+    await Assert.That(debuggerPath).IsEqualTo(@"Modeler\Generated\Program.cs");
+  }
+
+  [Test]
+  public async Task MappingLeavesUnmatchedPathsUnchanged()
+  {
+    var mapper = CreateMapper(("Modeler", "/work/modeler"));
+
+    var debuggerPath = mapper.MapDebuggerToClient("Other/Program.cs");
+    var clientPath = mapper.MapClientToDebugger("/tmp/Program.cs");
+
+    await Assert.That(debuggerPath).IsEqualTo("Other/Program.cs");
+    await Assert.That(clientPath).IsEqualTo("/tmp/Program.cs");
+  }
+
+  [Test]
+  public async Task MappingUsesPlatformPathCaseRules()
+  {
+    var mapper = CreateMapper(("Modeler", "/work/modeler"));
+
+    var result = mapper.MapDebuggerToClient("modeler/Program.cs");
+
+    var expected = OperatingSystem.IsWindows()
+      ? "/work/modeler/Program.cs"
+      : "modeler/Program.cs";
+    await Assert.That(result).IsEqualTo(expected);
+  }
+
+  [Test]
+  public void ConfigureRejectsAmbiguousClientPrefixes()
+  {
+    var mapper = new SourcePathMapper();
+
+    Assert.Throws<ArgumentException>(() => mapper.Configure(new Dictionary<string, string>
+    {
+      ["First"] = "/work/modeler/",
+      ["Second"] = @"\work\modeler"
+    }));
+  }
+
+  [Test]
+  public async Task ConfigureWithEmptyMappingsClearsPreviousMappings()
+  {
+    var mapper = CreateMapper(("Modeler", "/work/modeler"));
+
+    mapper.Configure(new Dictionary<string, string>());
+
+    await Assert.That(mapper.MapDebuggerToClient("Modeler/Program.cs")).IsEqualTo("Modeler/Program.cs");
+    await Assert.That(mapper.MapClientToDebugger("/work/modeler/Program.cs")).IsEqualTo("/work/modeler/Program.cs");
+  }
+
+  [Test]
+  public void ConfigureRejectsNestedClientPrefixesForUnrelatedDebuggerPrefixes()
+  {
+    var mapper = new SourcePathMapper();
+
+    Assert.Throws<ArgumentException>(() => mapper.Configure(new Dictionary<string, string>
+    {
+      ["src/First"] = "/work",
+      ["src/Second"] = "/work/Nested"
+    }));
+  }
+
+  [Test]
+  public void ConfigureRejectsNestedDebuggerPrefixesForUnrelatedClientPrefixes()
+  {
+    var mapper = new SourcePathMapper();
+
+    Assert.Throws<ArgumentException>(() => mapper.Configure(new Dictionary<string, string>
+    {
+      ["src"] = "/work/First",
+      ["src/Nested"] = "/work/Second"
+    }));
+  }
+
+  [Test]
+  public async Task ConfigureAcceptsAlignedNestedPrefixes()
+  {
+    var mapper = CreateMapper(
+      ("src", "/work"),
+      ("src/Nested", "/work/Nested"));
+
+    await Assert.That(mapper.MapDebuggerToClient("src/Nested/Program.cs"))
+      .IsEqualTo("/work/Nested/Program.cs");
+    await Assert.That(mapper.MapClientToDebugger("/work/Nested/Program.cs"))
+      .IsEqualTo("src/Nested/Program.cs");
+  }
+
+  [Test]
+  public async Task ConfigureAcceptsUnrelatedSiblingPrefixes()
+  {
+    var mapper = CreateMapper(
+      ("src/First", "/work/First"),
+      ("src/Second", "/work/Second"));
+
+    await Assert.That(mapper.MapDebuggerToClient("src/Second/Program.cs"))
+      .IsEqualTo("/work/Second/Program.cs");
+  }
+
+  private static SourcePathMapper CreateMapper(params (string Debugger, string Client)[] mappings)
+  {
+    var mapper = new SourcePathMapper();
+    mapper.Configure(mappings.ToDictionary(mapping => mapping.Debugger, mapping => mapping.Client));
+    return mapper;
+  }
+}

--- a/EasyDotnet.Debugger/DebugSessionFactory.cs
+++ b/EasyDotnet.Debugger/DebugSessionFactory.cs
@@ -12,7 +12,8 @@ public class DebugSessionFactory(ILoggerFactory loggerFactory) : IDebugSessionFa
     Func<InterceptableAttachRequest, IDebuggerProxy, Task<InterceptableAttachRequest>> attachRequestRewriter,
     bool applyValueConverters,
     bool memCpuUsage,
-    IVariableLocationResolver? variableLocationResolver = null)
+    IVariableLocationResolver? variableLocationResolver = null,
+    IReadOnlyDictionary<string, string>? automaticSourceFileMap = null)
   {
     var valueConverterService = new ValueConverterService(
       loggerFactory.CreateLogger<ValueConverterService>(),
@@ -28,6 +29,7 @@ public class DebugSessionFactory(ILoggerFactory loggerFactory) : IDebugSessionFa
 
     var frameSourceTracker = variableLocationResolver is not null ? new FrameSourceTracker() : null;
     var sourcePathMapper = new SourcePathMapper();
+    sourcePathMapper.Configure(automaticSourceFileMap ?? new Dictionary<string, string>());
 
     var clientInterceptor = new ClientMessageInterceptor(
       loggerFactory.CreateLogger<ClientMessageInterceptor>(),

--- a/EasyDotnet.Debugger/DebugSessionFactory.cs
+++ b/EasyDotnet.Debugger/DebugSessionFactory.cs
@@ -27,6 +27,7 @@ public class DebugSessionFactory(ILoggerFactory loggerFactory) : IDebugSessionFa
     DebugSessionCoordinator? coordinator = null;
 
     var frameSourceTracker = variableLocationResolver is not null ? new FrameSourceTracker() : null;
+    var sourcePathMapper = new SourcePathMapper();
 
     var clientInterceptor = new ClientMessageInterceptor(
       loggerFactory.CreateLogger<ClientMessageInterceptor>(),
@@ -34,7 +35,8 @@ public class DebugSessionFactory(ILoggerFactory loggerFactory) : IDebugSessionFa
       (a) => attachRequestRewriter(a, coordinator!.Proxy!),
       processId => coordinator?.NotifyDebugeeProcessStarted(processId),
       () => coordinator?.NotifyConfigurationDone(),
-      frameSourceTracker);
+      frameSourceTracker,
+      sourcePathMapper);
 
     var debuggerInterceptor = new DebuggerMessageInterceptor(
       loggerFactory.CreateLogger<DebuggerMessageInterceptor>(),
@@ -46,7 +48,8 @@ public class DebugSessionFactory(ILoggerFactory loggerFactory) : IDebugSessionFa
       (command, message) => coordinator?.NotifyDebugSessionStartFailed(command, message),
       exitCode => coordinator?.NotifyExited(exitCode),
       frameSourceTracker,
-      variableLocationResolver);
+      variableLocationResolver,
+      sourcePathMapper);
 
     coordinator = new DebugSessionCoordinator(
      loggerFactory.CreateLogger<DebugSessionCoordinator>(),

--- a/EasyDotnet.Debugger/Interfaces/IDebugSessionFactory.cs
+++ b/EasyDotnet.Debugger/Interfaces/IDebugSessionFactory.cs
@@ -9,5 +9,6 @@ public interface IDebugSessionFactory
     Func<InterceptableAttachRequest, IDebuggerProxy, Task<InterceptableAttachRequest>> attachRequestRewriter,
     bool applyValueConverters,
     bool memCpuUsage,
-    IVariableLocationResolver? variableLocationResolver = null);
+    IVariableLocationResolver? variableLocationResolver = null,
+    IReadOnlyDictionary<string, string>? automaticSourceFileMap = null);
 }

--- a/EasyDotnet.Debugger/Messages/DapProtocolMessages.cs
+++ b/EasyDotnet.Debugger/Messages/DapProtocolMessages.cs
@@ -70,21 +70,32 @@ public class SetBreakpointsRequest : Request
 
 public class SetBreakpointsArguments
 {
-  public required List<Breakpoint> Breakpoints { get; set; }
-  public required List<int> Lines { get; set; }
+  public List<Breakpoint>? Breakpoints { get; set; }
+  public List<int>? Lines { get; set; }
   public required Source Source { get; set; }
-  public required bool SourceModified { get; set; }
+  public bool? SourceModified { get; set; }
+
+  [JsonExtensionData]
+  public Dictionary<string, JsonElement>? ExtraProperties { get; set; }
 }
 
 public class Breakpoint
 {
   public required int Line { get; set; }
+
+  [JsonExtensionData]
+  public Dictionary<string, JsonElement>? ExtraProperties { get; set; }
 }
 
 public class Source
 {
-  public required string Name { get; set; }
-  public required string Path { get; set; }
+  public string? Name { get; set; }
+  public string? Path { get; set; }
+  public List<Source>? Sources { get; set; }
+  public JsonElement? AdapterData { get; set; }
+
+  [JsonExtensionData]
+  public Dictionary<string, JsonElement>? ExtraProperties { get; set; }
 }
 
 public class VariablesResponse : Response

--- a/EasyDotnet.Debugger/Services/SourcePathMapper.cs
+++ b/EasyDotnet.Debugger/Services/SourcePathMapper.cs
@@ -1,0 +1,316 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace EasyDotnet.Debugger.Services;
+
+public sealed class SourcePathMapper
+{
+  // NetCoreDbg indexes source paths using the debugger host's case rules; this proxy runs on that same host.
+  private readonly StringComparer _prefixComparer = OperatingSystem.IsWindows()
+    ? StringComparer.OrdinalIgnoreCase
+    : StringComparer.Ordinal;
+  private readonly StringComparison _prefixComparison = OperatingSystem.IsWindows()
+    ? StringComparison.OrdinalIgnoreCase
+    : StringComparison.Ordinal;
+  private PathMapping[] _debuggerMappings = [];
+  private PathMapping[] _clientMappings = [];
+
+  public void Configure(IReadOnlyDictionary<string, string> sourceFileMap)
+  {
+    ArgumentNullException.ThrowIfNull(sourceFileMap);
+
+    var validator = CreateValidator();
+    foreach (var entry in sourceFileMap)
+    {
+      validator.Add(entry.Key, entry.Value);
+    }
+
+    validator.ApplyTo(this);
+  }
+
+  public Validator CreateValidator() => new(_prefixComparer, _prefixComparison);
+
+  public string MapDebuggerToClient(string path) => MapPath(
+    path,
+    _debuggerMappings,
+    static mapping => mapping.DebuggerPrefix,
+    static mapping => mapping.ClientPrefix,
+    static mapping => mapping.ClientSeparator);
+
+  public string MapClientToDebugger(string path) => MapPath(
+    path,
+    _clientMappings,
+    static mapping => mapping.ClientPrefix,
+    static mapping => mapping.DebuggerPrefix,
+    static mapping => mapping.DebuggerSeparator);
+
+  public JsonElement RewriteClientSources(JsonElement element) => RewriteSources(element, MapClientToDebugger);
+
+  public JsonElement RewriteDebuggerSources(JsonElement element) => RewriteSources(element, MapDebuggerToClient);
+
+  private string MapPath(
+    string path,
+    PathMapping[] mappings,
+    Func<PathMapping, string> sourcePrefixSelector,
+    Func<PathMapping, string> destinationPrefixSelector,
+    Func<PathMapping, char> destinationSeparatorSelector)
+  {
+    var normalizedPath = NormalizePath(path);
+    foreach (var mapping in mappings)
+    {
+      var sourcePrefix = sourcePrefixSelector(mapping);
+      if (IsPrefixMatch(normalizedPath, sourcePrefix))
+      {
+        return ReplacePrefix(
+          normalizedPath,
+          sourcePrefix,
+          destinationPrefixSelector(mapping),
+          destinationSeparatorSelector(mapping));
+      }
+    }
+
+    return path;
+  }
+
+  private bool IsPrefixMatch(string path, string prefix)
+    => IsPrefixMatch(path, prefix, _prefixComparison);
+
+  private static bool IsPrefixMatch(string path, string prefix, StringComparison prefixComparison)
+  {
+    if (path.Equals(prefix, prefixComparison))
+    {
+      return true;
+    }
+    if (prefix == "/")
+    {
+      return path.StartsWith("/", prefixComparison);
+    }
+
+    return path.Length > prefix.Length
+      && path.StartsWith(prefix, prefixComparison)
+      && path[prefix.Length] == '/';
+  }
+
+  private static int GetNestingRelationship(
+      string firstPrefix,
+      string secondPrefix,
+      StringComparison prefixComparison)
+  {
+    if (IsPrefixMatch(secondPrefix, firstPrefix, prefixComparison))
+    {
+      return 1;
+    }
+    if (IsPrefixMatch(firstPrefix, secondPrefix, prefixComparison))
+    {
+      return -1;
+    }
+
+    return 0;
+  }
+
+  private static string ReplacePrefix(string path, string sourcePrefix, string destinationPrefix, char destinationSeparator)
+  {
+    var suffixStart = sourcePrefix == "/" ? 1 : sourcePrefix.Length;
+    var suffix = path[suffixStart..].TrimStart('/').Replace('/', destinationSeparator);
+    var destination = destinationPrefix.Replace('/', destinationSeparator);
+
+    if (suffix.Length == 0)
+    {
+      return destination;
+    }
+
+    return destination.EndsWith(destinationSeparator)
+      ? destination + suffix
+      : destination + destinationSeparator + suffix;
+  }
+
+  private JsonElement RewriteSources(JsonElement element, Func<string, string> mapPath)
+  {
+    if (_debuggerMappings.Length == 0)
+    {
+      return element;
+    }
+
+    var root = JsonNode.Parse(element.GetRawText())!;
+    RewriteContainedSources(root, mapPath);
+    return JsonSerializer.SerializeToElement(root);
+  }
+
+  private static void RewriteContainedSources(JsonNode? node, Func<string, string> mapPath)
+  {
+    switch (node)
+    {
+      case JsonObject obj:
+        foreach (var property in obj)
+        {
+          if (property.Key.Equals("source", StringComparison.OrdinalIgnoreCase) && property.Value is JsonObject source)
+          {
+            RewriteSource(source, mapPath);
+          }
+          else if (property.Key.Equals("sources", StringComparison.OrdinalIgnoreCase) && property.Value is JsonArray sources)
+          {
+            foreach (var item in sources)
+            {
+              if (item is JsonObject nestedSource)
+              {
+                RewriteSource(nestedSource, mapPath);
+              }
+            }
+          }
+          else if (IsSourceContainer(property.Key))
+          {
+            RewriteContainedSources(property.Value, mapPath);
+          }
+          else if (property.Key.Equals("instructions", StringComparison.OrdinalIgnoreCase) && property.Value is JsonArray instructions)
+          {
+            RewriteDisassembledInstructionLocations(instructions, mapPath);
+          }
+        }
+        break;
+      case JsonArray array:
+        foreach (var item in array)
+        {
+          RewriteContainedSources(item, mapPath);
+        }
+        break;
+    }
+  }
+
+  private static bool IsSourceContainer(string propertyName) =>
+    propertyName.Equals("stackFrames", StringComparison.OrdinalIgnoreCase)
+    || propertyName.Equals("scopes", StringComparison.OrdinalIgnoreCase)
+    || propertyName.Equals("breakpoints", StringComparison.OrdinalIgnoreCase)
+    || propertyName.Equals("breakpoint", StringComparison.OrdinalIgnoreCase);
+
+  private static void RewriteDisassembledInstructionLocations(JsonArray instructions, Func<string, string> mapPath)
+  {
+    foreach (var instruction in instructions.OfType<JsonObject>())
+    {
+      foreach (var property in instruction)
+      {
+        if (property.Key.Equals("location", StringComparison.OrdinalIgnoreCase) && property.Value is JsonObject location)
+        {
+          RewriteSource(location, mapPath);
+        }
+      }
+    }
+  }
+
+  private static void RewriteSource(JsonObject source, Func<string, string> mapPath)
+  {
+    if (source["path"] is JsonValue pathValue && pathValue.TryGetValue<string>(out var path))
+    {
+      source["path"] = mapPath(path);
+    }
+
+    RewriteContainedSources(source, mapPath);
+  }
+
+  private static PathMapping CreateMapping(string debuggerPrefix, string clientPrefix)
+  {
+    if (string.IsNullOrEmpty(debuggerPrefix))
+    {
+      throw new ArgumentException("sourceFileMap debugger prefixes cannot be empty.", nameof(debuggerPrefix));
+    }
+    if (string.IsNullOrEmpty(clientPrefix))
+    {
+      throw new ArgumentException("sourceFileMap client prefixes cannot be empty.", nameof(clientPrefix));
+    }
+
+    return new PathMapping(
+      NormalizePrefix(debuggerPrefix),
+      NormalizePrefix(clientPrefix),
+      GetSeparator(debuggerPrefix),
+      GetSeparator(clientPrefix));
+  }
+
+  private static string NormalizePrefix(string prefix)
+  {
+    var normalized = NormalizePath(prefix);
+    var trimmed = normalized.TrimEnd('/');
+    return trimmed.Length == 0 && normalized.StartsWith('/') ? "/" : trimmed;
+  }
+
+  private static string NormalizePath(string path) => path.Replace('\\', '/');
+
+  private static char GetSeparator(string prefix)
+  {
+    var lastSlash = prefix.LastIndexOf('/');
+    var lastBackslash = prefix.LastIndexOf('\\');
+    if (lastBackslash > lastSlash)
+    {
+      return '\\';
+    }
+    if (lastSlash >= 0)
+    {
+      return '/';
+    }
+
+    return prefix.Length > 1 && prefix[1] == ':' ? '\\' : '/';
+  }
+
+  public sealed class Validator
+  {
+    private readonly StringComparer _prefixComparer;
+    private readonly StringComparison _prefixComparison;
+    private readonly List<PathMapping> _mappings = [];
+
+    internal Validator(StringComparer prefixComparer, StringComparison prefixComparison)
+    {
+      _prefixComparer = prefixComparer;
+      _prefixComparison = prefixComparison;
+    }
+
+    public void Add(string debuggerPrefix, string clientPrefix)
+    {
+      var mapping = CreateMapping(debuggerPrefix, clientPrefix);
+      foreach (var existing in _mappings)
+      {
+        if (_prefixComparer.Equals(existing.DebuggerPrefix, mapping.DebuggerPrefix))
+        {
+          throw new ArgumentException(
+              $"sourceFileMap contains duplicate debugger prefix '{mapping.DebuggerPrefix}'.",
+              "sourceFileMap");
+        }
+        if (_prefixComparer.Equals(existing.ClientPrefix, mapping.ClientPrefix))
+        {
+          throw new ArgumentException(
+              $"sourceFileMap contains ambiguous client prefix '{mapping.ClientPrefix}'.",
+              "sourceFileMap");
+        }
+
+        var debuggerRelationship = GetNestingRelationship(
+            existing.DebuggerPrefix,
+            mapping.DebuggerPrefix,
+            _prefixComparison);
+        var clientRelationship = GetNestingRelationship(
+            existing.ClientPrefix,
+            mapping.ClientPrefix,
+            _prefixComparison);
+        if (debuggerRelationship != clientRelationship)
+        {
+          throw new ArgumentException(
+              $"sourceFileMap entries '{existing.DebuggerPrefix}' and '{mapping.DebuggerPrefix}' have asymmetric client prefix nesting.",
+              "sourceFileMap");
+        }
+      }
+
+      _mappings.Add(mapping);
+    }
+
+    public bool AreEquivalentPrefixes(string first, string second) =>
+      _prefixComparer.Equals(NormalizePrefix(first), NormalizePrefix(second));
+
+    internal void ApplyTo(SourcePathMapper mapper)
+    {
+      mapper._debuggerMappings = [.. _mappings.OrderByDescending(mapping => mapping.DebuggerPrefix.Length)];
+      mapper._clientMappings = [.. _mappings.OrderByDescending(mapping => mapping.ClientPrefix.Length)];
+    }
+  }
+
+  private sealed record PathMapping(
+    string DebuggerPrefix,
+    string ClientPrefix,
+    char DebuggerSeparator,
+    char ClientSeparator);
+}

--- a/EasyDotnet.Debugger/Services/SourcePathMapper.cs
+++ b/EasyDotnet.Debugger/Services/SourcePathMapper.cs
@@ -301,6 +301,14 @@ public sealed class SourcePathMapper
     public bool AreEquivalentPrefixes(string first, string second) =>
       _prefixComparer.Equals(NormalizePrefix(first), NormalizePrefix(second));
 
+    public bool AreOverlappingPrefixes(string first, string second)
+    {
+      var normalizedFirst = NormalizePrefix(first);
+      var normalizedSecond = NormalizePrefix(second);
+      return IsPrefixMatch(normalizedFirst, normalizedSecond, _prefixComparison)
+        || IsPrefixMatch(normalizedSecond, normalizedFirst, _prefixComparison);
+    }
+
     internal void ApplyTo(SourcePathMapper mapper)
     {
       mapper._debuggerMappings = [.. _mappings.OrderByDescending(mapping => mapping.DebuggerPrefix.Length)];

--- a/EasyDotnet.Debugger/Session/ClientMessageInterceptor.cs
+++ b/EasyDotnet.Debugger/Session/ClientMessageInterceptor.cs
@@ -13,9 +13,12 @@ public class ClientMessageInterceptor(
   Func<InterceptableAttachRequest, Task<InterceptableAttachRequest>> attachRequestRewriter,
   Action<int> onDebugeeProcessStarted,
   Action onConfigurationDone,
-  FrameSourceTracker? frameSourceTracker = null
+  FrameSourceTracker? frameSourceTracker = null,
+  SourcePathMapper? sourcePathMapper = null
   ) : IDapMessageInterceptor
 {
+  private readonly SourcePathMapper _sourcePathMapper = sourcePathMapper ?? new SourcePathMapper();
+
   private static readonly JsonSerializerOptions LoggingOptions = new()
   {
     PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -36,8 +39,8 @@ public class ClientMessageInterceptor(
         InterceptableCompletionsRequest complReq => await HandleCompletionsRequestAsync(complReq, proxy, cancellationToken),
         ScopesRequest scopesReq => HandleScopesRequest(scopesReq, proxy),
         SetBreakpointsRequest bpReq => HandleBreakpointsRequest(bpReq),
-        Request req when req.Command == "evaluate" => await HandleEvaluateRequestAsync(req, proxy, cancellationToken),
-        Request req => LogAndPassthrough(req),
+        Request req when req.Command == "evaluate" => await HandleEvaluateRequestAsync(RewriteRequestSources(req), proxy, cancellationToken),
+        Request req => HandleRequest(req),
         _ => throw new Exception($"Unsupported DAP message from client: {message}")
       };
     }
@@ -605,15 +608,30 @@ public class ClientMessageInterceptor(
 
   private SetBreakpointsRequest HandleBreakpointsRequest(SetBreakpointsRequest request)
   {
-    if (OperatingSystem.IsWindows())
-    {
-      request.Arguments.Source.Path = request.Arguments.Source.Path.Replace('/', '\\');
-      logger.LogDebug("[CLIENT] Normalized breakpoint path separators");
-    }
+    MapSourceToDebugger(request.Arguments.Source);
 
     logger.LogDebug("[CLIENT] Set breakpoints: {request}",
       JsonSerializer.Serialize(request, LoggingOptions));
     return request;
+  }
+
+  private void MapSourceToDebugger(Source source)
+  {
+    if (source.Path is { } path)
+    {
+      source.Path = _sourcePathMapper.MapClientToDebugger(path);
+
+      if (OperatingSystem.IsWindows())
+      {
+        source.Path = source.Path.Replace('/', '\\');
+        logger.LogDebug("[CLIENT] Normalized breakpoint path separators");
+      }
+    }
+
+    foreach (var nestedSource in source.Sources ?? [])
+    {
+      MapSourceToDebugger(nestedSource);
+    }
   }
 
   private ScopesRequest HandleScopesRequest(ScopesRequest request, IDebuggerProxy proxy)
@@ -666,6 +684,19 @@ public class ClientMessageInterceptor(
       onConfigurationDone();
     }
     logger.LogDebug("[CLIENT] Request: {command}", request.Command);
+    return request;
+  }
+
+  private Request HandleRequest(Request request)
+    => LogAndPassthrough(RewriteRequestSources(request));
+
+  private Request RewriteRequestSources(Request request)
+  {
+    if (request.Arguments is { } arguments)
+    {
+      request.Arguments = _sourcePathMapper.RewriteClientSources(arguments);
+    }
+
     return request;
   }
 }

--- a/EasyDotnet.Debugger/Session/DebuggerMessageInterceptor.cs
+++ b/EasyDotnet.Debugger/Session/DebuggerMessageInterceptor.cs
@@ -16,12 +16,14 @@ public class DebuggerMessageInterceptor(
   Action<string, string?> onDebugSessionStartFailed,
   Action<int?>? onExited = null,
   FrameSourceTracker? frameSourceTracker = null,
-  IVariableLocationResolver? variableLocationResolver = null) : IDapMessageInterceptor
+  IVariableLocationResolver? variableLocationResolver = null,
+  SourcePathMapper? sourcePathMapper = null) : IDapMessageInterceptor
 
 {
   private readonly object _initializeGate = new();
   private Event? _heldInitializedEvent;
   private bool _initializeResponseForwarded;
+  private readonly SourcePathMapper _sourcePathMapper = sourcePathMapper ?? new SourcePathMapper();
 
   public async Task<ProtocolMessage?> InterceptAsync(
     ProtocolMessage message,
@@ -64,6 +66,11 @@ public class DebuggerMessageInterceptor(
   private async Task<ProtocolMessage?> HandleResponse(Response response, IDebuggerProxy proxy, CancellationToken cancellationToken)
   {
     logger.LogDebug("[DEBUGGER] Response: {command}", response.Command);
+
+    if (response.Body is { } body)
+    {
+      response.Body = _sourcePathMapper.RewriteDebuggerSources(body);
+    }
 
     TryReportDebugSessionStartState(response);
 
@@ -329,6 +336,11 @@ public class DebuggerMessageInterceptor(
 
   private Task<ProtocolMessage?> HandleEvent(Event evt)
   {
+    if (evt.Body is { } body)
+    {
+      evt.Body = _sourcePathMapper.RewriteDebuggerSources(body);
+    }
+
     if (evt.EventName == "initialized" && TryHoldInitializedEvent(evt))
     {
       logger.LogDebug("[DEBUGGER] Holding initialized event until the initialize response is forwarded");

--- a/EasyDotnet.IDE.Tests/Debugger/DebugOrchestratorSourcePathMapTests.cs
+++ b/EasyDotnet.IDE.Tests/Debugger/DebugOrchestratorSourcePathMapTests.cs
@@ -1,0 +1,206 @@
+using System.Text.Json;
+using EasyDotnet.BuildServer.Contracts;
+using EasyDotnet.Debugger;
+using EasyDotnet.Debugger.Interfaces;
+using EasyDotnet.Debugger.Messages;
+using EasyDotnet.Debugger.Services;
+using EasyDotnet.IDE.Models.Client;
+using EasyDotnet.IDE.Project.Services;
+using EasyDotnet.IDE.Services;
+using EasyDotnet.IDE.Types;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace EasyDotnet.IDE.Tests.Debugger;
+
+public sealed class DebugOrchestratorSourcePathMapTests
+{
+  [Test]
+  public async Task StartClientDebugSessionAwaitsExactGraphResultAndPassesMappingsToFactory()
+  {
+    var graph = new ControllableProjectGraphService();
+    var factory = new CapturingDebugSessionFactory();
+    var orchestrator = CreateOrchestrator(graph, factory);
+
+    var start = orchestrator.StartClientDebugSessionAsync(
+        "App.csproj",
+        new StubDebugSessionStrategy(),
+        CancellationToken.None);
+
+    await Assert.That(start.IsCompleted).IsFalse();
+    await Assert.That(factory.AutomaticSourceFileMap).IsNull();
+
+    graph.Complete(CreateSnapshot("/work/App=Mapped/App"));
+
+    await Assert.ThrowsAsync<FactoryCalledException>(async () => await start);
+    await Assert.That(factory.AutomaticSourceFileMap).IsNotNull();
+    await Assert.That(factory.AutomaticSourceFileMap!["Mapped/App"]).IsEqualTo("/work/App");
+  }
+
+  [Test]
+  [Arguments(false)]
+  [Arguments(true)]
+  public async Task StartClientDebugSessionContinuesWithEmptyMappingsWithoutGraphOrAfterGraphFailure(
+      bool graphFails)
+  {
+    var graph = new ControllableProjectGraphService();
+    if (graphFails)
+    {
+      graph.Fail(new InvalidOperationException("Graph evaluation failed"));
+    }
+    else
+    {
+      graph.Complete(null);
+    }
+    var factory = new CapturingDebugSessionFactory();
+    var orchestrator = CreateOrchestrator(graph, factory);
+
+    var start = orchestrator.StartClientDebugSessionAsync(
+        "App.csproj",
+        new StubDebugSessionStrategy(),
+        CancellationToken.None);
+
+    await Assert.ThrowsAsync<FactoryCalledException>(async () => await start);
+    await Assert.That(factory.AutomaticSourceFileMap).IsEmpty();
+  }
+
+  [Test]
+  public async Task StartClientDebugSessionContinuesWithEmptyMappingsWhenGraphWaitTimesOut()
+  {
+    var graph = new ControllableProjectGraphService();
+    var factory = new CapturingDebugSessionFactory();
+    var orchestrator = CreateOrchestrator(graph, factory, TimeSpan.Zero);
+
+    var start = orchestrator.StartClientDebugSessionAsync(
+        "App.csproj",
+        new StubDebugSessionStrategy(),
+        CancellationToken.None);
+
+    await Assert.ThrowsAsync<FactoryCalledException>(async () => await start);
+    await Assert.That(factory.AutomaticSourceFileMap).IsEmpty();
+  }
+
+  [Test]
+  public async Task StartClientDebugSessionPropagatesCallerCancellationWhileWaitingForGraph()
+  {
+    var graph = new ControllableProjectGraphService();
+    var factory = new CapturingDebugSessionFactory();
+    var orchestrator = CreateOrchestrator(graph, factory, TimeSpan.FromMinutes(1));
+    using var cancellation = new CancellationTokenSource();
+
+    var start = orchestrator.StartClientDebugSessionAsync(
+        "App.csproj",
+        new StubDebugSessionStrategy(),
+        cancellation.Token);
+    cancellation.Cancel();
+
+    await Assert.ThrowsAsync<OperationCanceledException>(async () => await start);
+    await Assert.That(factory.AutomaticSourceFileMap).IsNull();
+  }
+
+  private static DebugOrchestrator CreateOrchestrator(
+      IProjectGraphService projectGraphService,
+      CapturingDebugSessionFactory debugSessionFactory,
+      TimeSpan? automaticSourceFileMapWaitTimeout = null) => new(
+    new InvokingDebugSessionManager(),
+    debugSessionFactory,
+    editorService: null!,
+    new ClientService
+    {
+      ClientOptions = new ClientOptions(new DebuggerOptions(
+          BinaryPath: "/tmp/debugger",
+          Engine: "netcoredbg"))
+    },
+    variableLocationResolver: null!,
+    projectGraphService,
+    new MsBuildSourcePathMapProvider(NullLogger<MsBuildSourcePathMapProvider>.Instance),
+    NullLogger<DebugOrchestrator>.Instance,
+    automaticSourceFileMapWaitTimeout);
+
+  private static ProjectGraphSnapshot CreateSnapshot(string pathMap)
+  {
+    var raw = JsonSerializer.Deserialize<DotnetProject>(JsonSerializer.Serialize(new { PathMap = pathMap }))!;
+    var project = new ValidatedDotnetProject
+    {
+      TargetFramework = "net8.0",
+      OutputType = "Library",
+      ProjectPath = "App.csproj",
+      ProjectFullPath = "/work/App/App.csproj",
+      ProjectName = "App",
+      AssemblyName = "App",
+      TargetPath = "/work/App/App.dll",
+      Raw = raw
+    };
+    return new ProjectGraphSnapshot("App.sln", [], [project], []);
+  }
+
+  private sealed class ControllableProjectGraphService : IProjectGraphService
+  {
+    private readonly TaskCompletionSource<ProjectGraphSnapshot?> _load =
+      new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public Task<ProjectGraphSnapshot?> LoadSolutionAsync(string solutionFile, CancellationToken ct = default) =>
+      throw new NotSupportedException();
+
+    public Task<ProjectGraphSnapshot?> WaitForCurrentLoadAsync(CancellationToken ct = default) =>
+      _load.Task.WaitAsync(ct);
+
+    public void Complete(ProjectGraphSnapshot? snapshot) => _load.SetResult(snapshot);
+
+    public void Fail(Exception exception) => _load.SetException(exception);
+  }
+
+  private sealed class CapturingDebugSessionFactory : IDebugSessionFactory
+  {
+    public IReadOnlyDictionary<string, string>? AutomaticSourceFileMap { get; private set; }
+
+    public EasyDotnet.Debugger.DebugSession Create(
+        Func<InterceptableAttachRequest, IDebuggerProxy, Task<InterceptableAttachRequest>> attachRequestRewriter,
+        bool applyValueConverters,
+        bool memCpuUsage,
+        IVariableLocationResolver? variableLocationResolver = null,
+        IReadOnlyDictionary<string, string>? automaticSourceFileMap = null)
+    {
+      AutomaticSourceFileMap = automaticSourceFileMap is null
+        ? null
+        : new Dictionary<string, string>(automaticSourceFileMap);
+      throw new FactoryCalledException();
+    }
+  }
+
+  private sealed class InvokingDebugSessionManager : IDebugSessionManager
+  {
+    public Task<EasyDotnet.Debugger.DebugSession> StartServerSessionAsync(
+        string projectPath,
+        string sessionId,
+        Func<Task<EasyDotnet.Debugger.DebugSession>> sessionFactory,
+        CancellationToken cancellationToken) => sessionFactory();
+
+    public Task<EasyDotnet.Debugger.DebugSession> StartClientSessionAsync(
+        string projectPath,
+        Func<Task<EasyDotnet.Debugger.DebugSession>> sessionFactory,
+        CancellationToken cancellationToken) => sessionFactory();
+
+    public Task EndSessionAsync(string projectPath, CancellationToken cancellationToken) =>
+      throw new NotSupportedException();
+
+    public EasyDotnet.IDE.Services.DebugSession? GetSession(string projectPath) => null;
+
+    public bool HasActiveSession(string projectPath) => false;
+  }
+
+  private sealed class StubDebugSessionStrategy : IDebugSessionStrategy
+  {
+    public Task PrepareAsync(CancellationToken ct) => Task.CompletedTask;
+
+    public Task TransformRequestAsync(InterceptableAttachRequest request, IDebuggerProxy proxy) =>
+      Task.CompletedTask;
+
+    public Task<int>? GetProcessIdAsync() => null;
+
+    public void OnDebugSessionReady(EasyDotnet.Debugger.DebugSession debugSession, IDebuggerProxy proxy) { }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+  }
+
+  private sealed class FactoryCalledException : Exception;
+}

--- a/EasyDotnet.IDE.Tests/Project/MsBuildSourcePathMapProviderTests.cs
+++ b/EasyDotnet.IDE.Tests/Project/MsBuildSourcePathMapProviderTests.cs
@@ -1,0 +1,291 @@
+using System.Text.Json;
+using EasyDotnet.BuildServer.Contracts;
+using EasyDotnet.Debugger.Services;
+using EasyDotnet.IDE.Project.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace EasyDotnet.IDE.Tests.Project;
+
+public sealed class MsBuildSourcePathMapProviderTests
+{
+  [Test]
+  public async Task GetMappingsReversesMultipleEvaluatedPathMapEntries()
+  {
+    var provider = CreateProvider();
+    var snapshot = CreateSnapshot(
+        ("First.csproj", @"/work/First=Mapped/First,C:\work\Second=Mapped\Second"));
+
+    var mappings = provider.GetMappings(snapshot);
+
+    await Assert.That(mappings.Count).IsEqualTo(2);
+    await Assert.That(mappings["Mapped/First"]).IsEqualTo("/work/First");
+    await Assert.That(mappings[@"Mapped\Second"]).IsEqualTo(@"C:\work\Second");
+  }
+
+  [Test]
+  public async Task GetMappingsParsesDoubledCommaAndEqualsEscapes()
+  {
+    var provider = CreateProvider();
+    var snapshot = CreateSnapshot((
+        "Escaped.csproj",
+        "/work/with,,comma=Mapped/Comma,/work/with==equals=Mapped==Equals"));
+
+    var mappings = provider.GetMappings(snapshot);
+
+    await Assert.That(mappings.Count).IsEqualTo(2);
+    await Assert.That(mappings["Mapped/Comma"]).IsEqualTo("/work/with,comma");
+    await Assert.That(mappings["Mapped=Equals"]).IsEqualTo("/work/with=equals");
+  }
+
+  [Test]
+  public async Task GetMappingsOmitsIdentityMappings()
+  {
+    var provider = CreateProvider();
+    var snapshot = CreateSnapshot(("Identity.csproj", "/work/project=/work/project/"));
+
+    var mappings = provider.GetMappings(snapshot);
+
+    await Assert.That(mappings).IsEmpty();
+  }
+
+  [Test]
+  public async Task GetMappingsSkipsMalformedUnsupportedAndEmptyEntries()
+  {
+    var logger = new CapturingLogger<MsBuildSourcePathMapProvider>();
+    var provider = new MsBuildSourcePathMapProvider(logger);
+    var snapshot = CreateSnapshot((
+        "Malformed.csproj",
+        "missing-separator,/work/Valid=Mapped,too=many=parts,=EmptyDebugger,/empty="));
+
+    var mappings = provider.GetMappings(snapshot);
+
+    await Assert.That(mappings.Count).IsEqualTo(1);
+    await Assert.That(mappings["Mapped"]).IsEqualTo("/work/Valid");
+    await Assert.That(logger.Warnings.Count).IsEqualTo(4);
+    await Assert.That(logger.Warnings.All(message => message.Contains("Skipping unsupported PathMap entry"))).IsTrue();
+    await Assert.That(logger.Information).IsEquivalentTo([
+      "Automatic MSBuild PathMap discovery: 1 evaluated projects, 1 with nonempty PathMap, 1 accepted mappings, 0 identity entries omitted, 4 entries skipped, 0 conflicts skipped"
+    ]);
+  }
+
+  [Test]
+  public async Task GetMappingsIgnoresEmptyOuterEntries()
+  {
+    var logger = new CapturingLogger<MsBuildSourcePathMapProvider>();
+    var provider = new MsBuildSourcePathMapProvider(logger);
+    var snapshot = CreateSnapshot(("Empty.csproj", ",/work/Valid=Mapped,"));
+
+    var mappings = provider.GetMappings(snapshot);
+
+    await Assert.That(mappings.Count).IsEqualTo(1);
+    await Assert.That(mappings["Mapped"]).IsEqualTo("/work/Valid");
+    await Assert.That(logger.Warnings.Count).IsEqualTo(0);
+    await Assert.That(logger.Information).IsEquivalentTo([
+      "Automatic MSBuild PathMap discovery: 1 evaluated projects, 1 with nonempty PathMap, 1 accepted mappings, 0 identity entries omitted, 0 entries skipped, 0 conflicts skipped"
+    ]);
+  }
+
+  [Test]
+  public async Task GetMappingsDeduplicatesEquivalentEntries()
+  {
+    var logger = new CapturingLogger<MsBuildSourcePathMapProvider>();
+    var provider = new MsBuildSourcePathMapProvider(logger);
+    var snapshot = CreateSnapshot(
+        ("First.csproj", "/work/First=Mapped"),
+        ("Second.csproj", "/work/First=Mapped,/work/First/=Mapped/"));
+
+    var mappings = provider.GetMappings(snapshot);
+
+    await Assert.That(mappings.Count).IsEqualTo(1);
+    await Assert.That(mappings["Mapped"]).IsEqualTo("/work/First");
+    await Assert.That(logger.Warnings.Count).IsEqualTo(0);
+    await Assert.That(logger.Information).IsEquivalentTo([
+      "Automatic MSBuild PathMap discovery: 2 evaluated projects, 2 with nonempty PathMap, 1 accepted mappings, 0 identity entries omitted, 2 entries skipped, 0 conflicts skipped"
+    ]);
+  }
+
+  [Test]
+  public async Task GetMappingsOmitsDebuggerPrefixMappedToDifferentPhysicalRoots()
+  {
+    var logger = new CapturingLogger<MsBuildSourcePathMapProvider>();
+    var provider = new MsBuildSourcePathMapProvider(logger);
+    var snapshot = CreateSnapshot(
+        ("First.csproj", "/work/First=Mapped"),
+        ("Second.csproj", "/work/Second=Mapped"));
+
+    var mappings = provider.GetMappings(snapshot);
+
+    await Assert.That(mappings).IsEmpty();
+    await Assert.That(logger.Warnings).IsEquivalentTo([
+      "Quarantining PathMap entry /work/Second=Mapped from Second.csproj with accepted mappings /work/First=Mapped; debugger or physical prefix regions overlap"
+    ]);
+    await Assert.That(logger.Information).IsEquivalentTo([
+      "Automatic MSBuild PathMap discovery: 2 evaluated projects, 2 with nonempty PathMap, 0 accepted mappings, 0 identity entries omitted, 0 entries skipped, 2 conflicts skipped"
+    ]);
+  }
+
+  [Test]
+  [Arguments("/work/First=src,/work/Second=src/Nested")]
+  [Arguments("/work/Second=src/Nested,/work/First=src")]
+  [Arguments("/work/First=src,/work/First/Nested=other")]
+  [Arguments("/work/First/Nested=other,/work/First=src")]
+  public async Task GetMappingsQuarantinesAsymmetricPrefixConflictsInEitherOrder(string pathMap)
+  {
+    var provider = CreateProvider();
+    var snapshot = CreateSnapshot(("Nested.csproj", pathMap));
+
+    var mappings = provider.GetMappings(snapshot);
+
+    await Assert.That(mappings).IsEmpty();
+  }
+
+  [Test]
+  [Arguments("/work=src,/work/Nested=src/Nested")]
+  [Arguments("/work/Nested=src/Nested,/work=src")]
+  public async Task GetMappingsQuarantinesSymmetricOverlapsInEitherCompilerOrder(string pathMap)
+  {
+    var provider = CreateProvider();
+    var snapshot = CreateSnapshot(("Nested.csproj", pathMap));
+
+    var mappings = provider.GetMappings(snapshot);
+
+    await Assert.That(mappings).IsEmpty();
+  }
+
+  [Test]
+  public async Task ConflictingNestedDebuggerPrefixCannotFallThroughAcceptedAncestor()
+  {
+    var provider = CreateProvider();
+    var snapshot = CreateSnapshot((
+        "Nested.csproj",
+        "/work=src,/work/Nested=src/Nested,/other=src/Nested"));
+    var mapper = new SourcePathMapper();
+
+    mapper.Configure(provider.GetMappings(snapshot));
+
+    await Assert.That(mapper.MapDebuggerToClient("src/Nested/File.cs"))
+      .IsEqualTo("src/Nested/File.cs");
+  }
+
+  [Test]
+  public async Task QuarantinedCandidateAlsoRemovesMappingsItOverlapsInTheOtherPrefixSpace()
+  {
+    var logger = new CapturingLogger<MsBuildSourcePathMapProvider>();
+    var provider = new MsBuildSourcePathMapProvider(logger);
+    var snapshot = CreateSnapshot((
+        "Transitive.csproj",
+        "/safe=clean,/q1=q,/q2=q/Nested,/safe/Nested=q/Other"));
+
+    var mappings = provider.GetMappings(snapshot);
+
+    await Assert.That(mappings).IsEmpty();
+    await Assert.That(logger.Warnings.Count).IsEqualTo(2);
+    await Assert.That(logger.Information).IsEquivalentTo([
+      "Automatic MSBuild PathMap discovery: 1 evaluated projects, 1 with nonempty PathMap, 0 accepted mappings, 0 identity entries omitted, 0 entries skipped, 4 conflicts skipped"
+    ]);
+  }
+
+  [Test]
+  public async Task GetMappingsPreservesSeparatorsForSourcePathMapper()
+  {
+    var provider = CreateProvider();
+    var snapshot = CreateSnapshot(("Windows.csproj", @"C:\repo\Project=Mapped\Project"));
+    var mapper = new SourcePathMapper();
+
+    mapper.Configure(provider.GetMappings(snapshot));
+
+    await Assert.That(mapper.MapDebuggerToClient("Mapped/Project/File.cs"))
+      .IsEqualTo(@"C:\repo\Project\File.cs");
+    await Assert.That(mapper.MapClientToDebugger("C:/repo/Project/File.cs"))
+      .IsEqualTo(@"Mapped\Project\File.cs");
+  }
+
+  [Test]
+  public async Task GetMappingsUsesEvaluatedProjectOverrideValue()
+  {
+    var provider = CreateProvider();
+    var snapshot = CreateSnapshot(
+        ("Default.csproj", "/repo/Default=src/Default"),
+        ("Override.csproj", "/repo/Override=custom/ProjectName"));
+
+    var mappings = provider.GetMappings(snapshot);
+
+    await Assert.That(mappings["src/Default"]).IsEqualTo("/repo/Default");
+    await Assert.That(mappings["custom/ProjectName"]).IsEqualTo("/repo/Override");
+  }
+
+  [Test]
+  public async Task GetMappingsValidatesLargeMappingSetAndQuarantinesConflictingNesting()
+  {
+    var entries = Enumerable.Range(0, 200)
+      .Select(index => $"/work/Project{index}=src/Project{index}")
+      .Append("/other=src/Project0/Nested");
+    var provider = CreateProvider();
+    var snapshot = CreateSnapshot(("Large.csproj", string.Join(',', entries)));
+
+    var mappings = provider.GetMappings(snapshot);
+    var mapper = new SourcePathMapper();
+    mapper.Configure(mappings);
+
+    await Assert.That(mappings.Count).IsEqualTo(199);
+    await Assert.That(mappings["src/Project199"]).IsEqualTo("/work/Project199");
+    await Assert.That(mappings.ContainsKey("src/Project0")).IsFalse();
+    await Assert.That(mappings.ContainsKey("src/Project0/Nested")).IsFalse();
+    await Assert.That(mapper.MapDebuggerToClient("src/Project0/Nested/File.cs"))
+      .IsEqualTo("src/Project0/Nested/File.cs");
+  }
+
+  private static MsBuildSourcePathMapProvider CreateProvider() =>
+    new(NullLogger<MsBuildSourcePathMapProvider>.Instance);
+
+  private static ProjectGraphSnapshot CreateSnapshot(params (string ProjectPath, string PathMap)[] projects) =>
+    new(
+        "/repo/App.sln",
+        [],
+        [.. projects.Select(project => CreateProject(project.ProjectPath, project.PathMap))],
+        []);
+
+  private static ValidatedDotnetProject CreateProject(string projectPath, string pathMap)
+  {
+    var raw = JsonSerializer.Deserialize<DotnetProject>(JsonSerializer.Serialize(new { PathMap = pathMap }))!;
+    return new ValidatedDotnetProject
+    {
+      TargetFramework = "net8.0",
+      OutputType = "Library",
+      ProjectPath = projectPath,
+      ProjectFullPath = projectPath,
+      ProjectName = Path.GetFileNameWithoutExtension(projectPath),
+      AssemblyName = Path.GetFileNameWithoutExtension(projectPath),
+      TargetPath = Path.ChangeExtension(projectPath, ".dll"),
+      Raw = raw
+    };
+  }
+
+  private sealed class CapturingLogger<T> : ILogger<T>
+  {
+    public List<string> Warnings { get; } = [];
+    public List<string> Information { get; } = [];
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+      if (logLevel == LogLevel.Warning)
+      {
+        Warnings.Add(formatter(state, exception));
+      }
+      else if (logLevel == LogLevel.Information)
+      {
+        Information.Add(formatter(state, exception));
+      }
+    }
+  }
+}

--- a/EasyDotnet.IDE.Tests/Project/ProjectGraphServiceTests.cs
+++ b/EasyDotnet.IDE.Tests/Project/ProjectGraphServiceTests.cs
@@ -1,0 +1,106 @@
+using EasyDotnet.IDE.Interfaces;
+using EasyDotnet.IDE.Models.Solution;
+using EasyDotnet.IDE.Project.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.SolutionPersistence.Model;
+
+namespace EasyDotnet.IDE.Tests.Project;
+
+public sealed class ProjectGraphServiceTests
+{
+  [Test]
+  public async Task LoadSolutionAsyncRegistersCurrentLoadBeforeReturning()
+  {
+    var solutionService = new BlockingSolutionService();
+    var graph = new ProjectGraphService(
+        solutionService,
+        workspaceBuildHostManager: null!,
+        NullLogger<ProjectGraphService>.Instance);
+
+    var load = graph.LoadSolutionAsync("App.sln", CancellationToken.None);
+    var wait = graph.WaitForCurrentLoadAsync(CancellationToken.None);
+
+    await Assert.That(wait.IsCompleted).IsFalse();
+
+    solutionService.Complete("App.sln", []);
+    var loadedSnapshot = await load;
+    var waitedSnapshot = await wait;
+
+    await Assert.That(waitedSnapshot).IsSameReferenceAs(loadedSnapshot);
+    await Assert.That(graph.Snapshot).IsNotNull();
+  }
+
+  [Test]
+  public async Task WaitForCurrentLoadAsyncCompletesWhenNoLoadWasStarted()
+  {
+    var graph = new ProjectGraphService(
+        new BlockingSolutionService(),
+        workspaceBuildHostManager: null!,
+        NullLogger<ProjectGraphService>.Instance);
+
+    var snapshot = await graph.WaitForCurrentLoadAsync(CancellationToken.None);
+
+    await Assert.That(snapshot).IsNull();
+    await Assert.That(graph.Snapshot).IsNull();
+  }
+
+  [Test]
+  public async Task OlderOverlappingLoadCannotReplaceNewerSnapshotAndWaitersReceiveExactLoadResult()
+  {
+    var solutionService = new BlockingSolutionService();
+    var graph = new ProjectGraphService(
+        solutionService,
+        workspaceBuildHostManager: null!,
+        NullLogger<ProjectGraphService>.Instance);
+
+    var olderLoad = graph.LoadSolutionAsync("Older.sln", CancellationToken.None);
+    var olderWait = graph.WaitForCurrentLoadAsync(CancellationToken.None);
+    var newerLoad = graph.LoadSolutionAsync("Newer.sln", CancellationToken.None);
+    var newerWait = graph.WaitForCurrentLoadAsync(CancellationToken.None);
+
+    solutionService.Complete("Newer.sln", []);
+    var newerSnapshot = await newerLoad;
+    solutionService.Complete("Older.sln", []);
+    var olderSnapshot = await olderLoad;
+
+    await Assert.That(await olderWait).IsSameReferenceAs(olderSnapshot);
+    await Assert.That(await newerWait).IsSameReferenceAs(newerSnapshot);
+    await Assert.That(graph.Snapshot).IsSameReferenceAs(newerSnapshot);
+    await Assert.That(graph.Snapshot!.SolutionPath).IsEqualTo(Path.GetFullPath("Newer.sln"));
+  }
+
+  private sealed class BlockingSolutionService : ISolutionService
+  {
+    private readonly Dictionary<string, TaskCompletionSource<List<SolutionFileProject>>> _projects = [];
+
+    public void Complete(string solutionFilePath, List<SolutionFileProject> projects) =>
+      GetProjectsTask(solutionFilePath).SetResult(projects);
+
+    public Task<List<SolutionFileProject>> GetProjectsFromSolutionFile(
+        string solutionFilePath,
+        CancellationToken cancellationToken) => GetProjectsTask(solutionFilePath).Task.WaitAsync(cancellationToken);
+
+    public Task<SolutionModel> GetSolutionModelAsync(string solutionFilePath, CancellationToken cancellationToken) =>
+      throw new NotSupportedException();
+
+    public Task<bool> AddProjectToSolutionAsync(string solutionFilePath, string projectPath, CancellationToken cancellationToken) =>
+      throw new NotSupportedException();
+
+    public Task<bool> RemoveProjectFromSolutionAsync(string solutionFilePath, string projectPath, CancellationToken cancellationToken) =>
+      throw new NotSupportedException();
+
+    private TaskCompletionSource<List<SolutionFileProject>> GetProjectsTask(string solutionFilePath)
+    {
+      lock (_projects)
+      {
+        if (!_projects.TryGetValue(solutionFilePath, out var completion))
+        {
+          completion = new TaskCompletionSource<List<SolutionFileProject>>(TaskCreationOptions.RunContinuationsAsynchronously);
+          _projects.Add(solutionFilePath, completion);
+        }
+
+        return completion;
+      }
+    }
+  }
+}

--- a/EasyDotnet.IDE.Tests/Workspace/WorkspaceRunCommandBuilderTests.cs
+++ b/EasyDotnet.IDE.Tests/Workspace/WorkspaceRunCommandBuilderTests.cs
@@ -242,5 +242,6 @@ public sealed class WorkspaceRunCommandBuilderTests
         MSBuildProjectExtensionsPath: "/tmp/obj/",
         SelfContained: false,
         UserProfileRuntimeStorePath: null,
-        TargetPlatformIdentifier: null);
+        TargetPlatformIdentifier: null,
+        PathMap: null);
 }

--- a/EasyDotnet.IDE/Controllers/Initialize/InitializeController.cs
+++ b/EasyDotnet.IDE/Controllers/Initialize/InitializeController.cs
@@ -18,7 +18,7 @@ namespace EasyDotnet.IDE.Controllers.Initialize;
 public class InitializeController(
   IClientService clientService,
   IVisualStudioLocator locator,
-  ProjectGraphService projectGraphService,
+  IProjectGraphService projectGraphService,
   SdkService sdkService,
   INotificationService notificationService,
   UpdateCheckerService updateCheckerService,
@@ -81,19 +81,21 @@ public class InitializeController(
 
   private void LoadSolutionProjects(string solutionFile)
   {
-    _ = Task.Run(async () =>
-        {
-          try
-          {
-            await projectGraphService.LoadSolutionAsync(solutionFile, CancellationToken.None);
-            await notificationService.NotifySolutionProjectsLoaded();
-          }
-          catch (Exception e)
-          {
-            logger.LogError(e, "Failed to load solution projects");
-          }
+    var load = projectGraphService.LoadSolutionAsync(solutionFile, CancellationToken.None);
+    _ = ObserveSolutionLoadAsync(load);
+  }
 
-        });
+  private async Task ObserveSolutionLoadAsync(Task<ProjectGraphSnapshot?> load)
+  {
+    try
+    {
+      await load;
+      await notificationService.NotifySolutionProjectsLoaded();
+    }
+    catch (Exception e)
+    {
+      logger.LogError(e, "Failed to load solution projects");
+    }
   }
 
   private static async Task<string?> TryGetMsBuildPath(IVisualStudioLocator locator)

--- a/EasyDotnet.IDE/DiModules.cs
+++ b/EasyDotnet.IDE/DiModules.cs
@@ -100,6 +100,8 @@ public static class DiModules
     services.AddSingleton<ProjectEvaluationCache>();
     services.AddSingleton<WorkspaceBuildHostManager>();
     services.AddSingleton<ProjectGraphService>();
+    services.AddSingleton<IProjectGraphService>(services => services.GetRequiredService<ProjectGraphService>());
+    services.AddSingleton<MsBuildSourcePathMapProvider>();
     services.AddSingleton<SdkService>();
 
     services.AddSingleton<TestRunnerService>();

--- a/EasyDotnet.IDE/Project/Services/MsBuildSourcePathMapProvider.cs
+++ b/EasyDotnet.IDE/Project/Services/MsBuildSourcePathMapProvider.cs
@@ -1,0 +1,191 @@
+using System.Text;
+using EasyDotnet.Debugger.Services;
+using Microsoft.Extensions.Logging;
+
+namespace EasyDotnet.IDE.Project.Services;
+
+public sealed class MsBuildSourcePathMapProvider(ILogger<MsBuildSourcePathMapProvider> logger)
+{
+  public IReadOnlyDictionary<string, string> GetMappings(ProjectGraphSnapshot? snapshot)
+  {
+    var mappings = new Dictionary<string, string>(StringComparer.Ordinal);
+    var quarantinedDebuggerPrefixes = new List<string>();
+    var quarantinedPhysicalPrefixes = new List<string>();
+    var validator = new SourcePathMapper().CreateValidator();
+    var evaluatedProjectCount = snapshot?.EvaluatedProjects.Count ?? 0;
+    var projectsWithPathMap = 0;
+    var identityEntryCount = 0;
+    var skippedEntryCount = 0;
+    var conflictEntryCount = 0;
+
+    foreach (var project in snapshot?.EvaluatedProjects ?? [])
+    {
+      if (string.IsNullOrEmpty(project.Raw.PathMap))
+      {
+        continue;
+      }
+      projectsWithPathMap++;
+
+      foreach (var entry in SplitWithDoubledSeparatorEscaping(project.Raw.PathMap, ','))
+      {
+        if (entry.Length == 0)
+        {
+          continue;
+        }
+
+        if (!TryParseEntry(entry, out var debuggerPrefix, out var physicalPrefix))
+        {
+          skippedEntryCount++;
+          logger.LogWarning(
+              "Skipping unsupported PathMap entry {Entry} from {ProjectPath}",
+              entry,
+              project.ProjectFullPath);
+          continue;
+        }
+
+        var isIdentity = validator.AreEquivalentPrefixes(debuggerPrefix, physicalPrefix);
+        if (isIdentity)
+        {
+          identityEntryCount++;
+
+          // An omitted identity entry can still shadow an overlapping compiler mapping.
+          var overlappingMappings = mappings.Where(mapping =>
+              validator.AreOverlappingPrefixes(mapping.Key, debuggerPrefix)
+              || validator.AreOverlappingPrefixes(mapping.Value, physicalPrefix)).ToArray();
+          if (overlappingMappings.Length > 0)
+          {
+            foreach (var mapping in overlappingMappings)
+            {
+              mappings.Remove(mapping.Key);
+              quarantinedDebuggerPrefixes.Add(mapping.Key);
+              quarantinedPhysicalPrefixes.Add(mapping.Value);
+            }
+            conflictEntryCount += overlappingMappings.Length;
+            LogQuarantinedEntry(entry, project.ProjectFullPath, overlappingMappings);
+          }
+
+          quarantinedDebuggerPrefixes.Add(debuggerPrefix);
+          quarantinedPhysicalPrefixes.Add(physicalPrefix);
+          continue;
+        }
+
+        var duplicateMapping = mappings.FirstOrDefault(mapping =>
+            validator.AreEquivalentPrefixes(mapping.Key, debuggerPrefix)
+            && validator.AreEquivalentPrefixes(mapping.Value, physicalPrefix));
+        if (duplicateMapping.Key is not null)
+        {
+          skippedEntryCount++;
+          continue;
+        }
+
+        var overlapsQuarantine = quarantinedDebuggerPrefixes.Any(prefix =>
+            validator.AreOverlappingPrefixes(prefix, debuggerPrefix))
+          || quarantinedPhysicalPrefixes.Any(prefix =>
+            validator.AreOverlappingPrefixes(prefix, physicalPrefix));
+        var conflicts = mappings.Where(mapping =>
+            validator.AreOverlappingPrefixes(mapping.Key, debuggerPrefix)
+            || validator.AreOverlappingPrefixes(mapping.Value, physicalPrefix)).ToArray();
+        if (overlapsQuarantine || conflicts.Length > 0)
+        {
+          foreach (var mapping in conflicts)
+          {
+            mappings.Remove(mapping.Key);
+            quarantinedDebuggerPrefixes.Add(mapping.Key);
+            quarantinedPhysicalPrefixes.Add(mapping.Value);
+          }
+          quarantinedDebuggerPrefixes.Add(debuggerPrefix);
+          quarantinedPhysicalPrefixes.Add(physicalPrefix);
+          conflictEntryCount += conflicts.Length + 1;
+          if (conflicts.Length > 0)
+          {
+            LogQuarantinedEntry(entry, project.ProjectFullPath, conflicts);
+          }
+          else
+          {
+            logger.LogWarning(
+                "Skipping quarantined PathMap entry {Entry} from {ProjectPath}; debugger or physical prefix overlaps a conflicting region",
+                entry,
+                project.ProjectFullPath);
+          }
+          continue;
+        }
+
+        mappings.Add(debuggerPrefix, physicalPrefix);
+      }
+    }
+
+    logger.LogInformation(
+        "Automatic MSBuild PathMap discovery: {EvaluatedProjectCount} evaluated projects, {ProjectsWithPathMap} with nonempty PathMap, {AcceptedMappingCount} accepted mappings, {IdentityEntryCount} identity entries omitted, {SkippedEntryCount} entries skipped, {ConflictEntryCount} conflicts skipped",
+        evaluatedProjectCount,
+        projectsWithPathMap,
+        mappings.Count,
+        identityEntryCount,
+        skippedEntryCount,
+        conflictEntryCount);
+
+    return mappings;
+
+    void LogQuarantinedEntry(
+        string entry,
+        string projectPath,
+        IReadOnlyCollection<KeyValuePair<string, string>> conflicts)
+      => logger.LogWarning(
+          "Quarantining PathMap entry {Entry} from {ProjectPath} with accepted mappings {AcceptedMappings}; debugger or physical prefix regions overlap",
+          entry,
+          projectPath,
+          string.Join(", ", conflicts.Select(mapping => $"{mapping.Value}={mapping.Key}")));
+  }
+
+  private static bool TryParseEntry(
+      string entry,
+      out string debuggerPrefix,
+      out string physicalPrefix)
+  {
+    debuggerPrefix = "";
+    physicalPrefix = "";
+
+    var parts = SplitWithDoubledSeparatorEscaping(entry, '=');
+    if (parts.Length != 2)
+    {
+      return false;
+    }
+
+    physicalPrefix = parts[0];
+    debuggerPrefix = parts[1];
+    return physicalPrefix.Length > 0 && debuggerPrefix.Length > 0;
+  }
+
+  private static string[] SplitWithDoubledSeparatorEscaping(string value, char separator)
+  {
+    if (value.Length == 0)
+    {
+      return [];
+    }
+
+    var result = new List<string>();
+    var part = new StringBuilder();
+    var index = 0;
+    while (index < value.Length)
+    {
+      var character = value[index++];
+      if (character == separator)
+      {
+        if (index < value.Length && value[index] == separator)
+        {
+          index++;
+        }
+        else
+        {
+          result.Add(part.ToString());
+          part.Clear();
+          continue;
+        }
+      }
+
+      part.Append(character);
+    }
+
+    result.Add(part.ToString());
+    return [.. result];
+  }
+}

--- a/EasyDotnet.IDE/Project/Services/ProjectGraphService.cs
+++ b/EasyDotnet.IDE/Project/Services/ProjectGraphService.cs
@@ -12,13 +12,21 @@ public sealed record ProjectGraphSnapshot(
   IReadOnlyList<ValidatedDotnetProject> EvaluatedProjects,
   IReadOnlyList<ProjectEvaluationResult> FailedEvaluations);
 
+public interface IProjectGraphService
+{
+  Task<ProjectGraphSnapshot?> LoadSolutionAsync(string solutionFile, CancellationToken ct = default);
+  Task<ProjectGraphSnapshot?> WaitForCurrentLoadAsync(CancellationToken ct = default);
+}
+
 public class ProjectGraphService(
   ISolutionService solutionService,
   WorkspaceBuildHostManager workspaceBuildHostManager,
-  ILogger<ProjectGraphService> logger)
+  ILogger<ProjectGraphService> logger) : IProjectGraphService
 {
   private readonly object _sync = new();
   private ProjectGraphSnapshot? _snapshot;
+  private Task<ProjectGraphSnapshot?> _currentLoad = Task.FromResult<ProjectGraphSnapshot?>(null);
+  private long _loadGeneration;
 
   public ProjectGraphSnapshot? Snapshot
   {
@@ -31,7 +39,32 @@ public class ProjectGraphService(
     }
   }
 
-  public async Task LoadSolutionAsync(string solutionFile, CancellationToken ct = default)
+  public Task<ProjectGraphSnapshot?> LoadSolutionAsync(string solutionFile, CancellationToken ct = default)
+  {
+    lock (_sync)
+    {
+      _snapshot = null;
+      var generation = ++_loadGeneration;
+      _currentLoad = LoadSolutionCoreAsync(solutionFile, generation, ct);
+      return _currentLoad;
+    }
+  }
+
+  public async Task<ProjectGraphSnapshot?> WaitForCurrentLoadAsync(CancellationToken ct = default)
+  {
+    Task<ProjectGraphSnapshot?> currentLoad;
+    lock (_sync)
+    {
+      currentLoad = _currentLoad;
+    }
+
+    return await currentLoad.WaitAsync(ct);
+  }
+
+  private async Task<ProjectGraphSnapshot?> LoadSolutionCoreAsync(
+      string solutionFile,
+      long generation,
+      CancellationToken ct)
   {
     var solutionProjects = await solutionService.GetProjectsFromSolutionFile(solutionFile, ct);
     var projectPaths = solutionProjects.ConvertAll(x => x.AbsolutePath);
@@ -74,7 +107,10 @@ public class ProjectGraphService(
 
     lock (_sync)
     {
-      _snapshot = snapshot;
+      if (generation == _loadGeneration)
+      {
+        _snapshot = snapshot;
+      }
     }
 
     logger.LogInformation(
@@ -82,5 +118,7 @@ public class ProjectGraphService(
         solutionFile,
         evaluatedProjects.Count,
         failedEvaluations.Count);
+
+    return snapshot;
   }
 }

--- a/EasyDotnet.IDE/Services/DebugOrchestrator.cs
+++ b/EasyDotnet.IDE/Services/DebugOrchestrator.cs
@@ -5,6 +5,7 @@ using EasyDotnet.Debugger.Messages;
 using EasyDotnet.Debugger.Services;
 using EasyDotnet.IDE.DebuggerStrategies;
 using EasyDotnet.IDE.Interfaces;
+using EasyDotnet.IDE.Project.Services;
 using EasyDotnet.IDE.Types;
 using Microsoft.Extensions.Logging;
 
@@ -38,9 +39,14 @@ public class DebugOrchestrator(
     IEditorService editorService,
     IClientService clientService,
     IVariableLocationResolver variableLocationResolver,
-    ILogger<DebugOrchestrator> logger) : IDebugOrchestrator
+    IProjectGraphService projectGraphService,
+    MsBuildSourcePathMapProvider sourcePathMapProvider,
+    ILogger<DebugOrchestrator> logger,
+    TimeSpan? automaticSourceFileMapWaitTimeout = null) : IDebugOrchestrator
 {
   private readonly ConcurrentDictionary<string, Debugger.DebugSession> _sessionServices = new();
+  private readonly TimeSpan _automaticSourceFileMapWaitTimeout =
+    automaticSourceFileMapWaitTimeout ?? TimeSpan.FromSeconds(5);
 
   /// <summary>
   /// Budget for the whole DAP start handshake, from session start to the point we can resume the
@@ -158,6 +164,7 @@ public class DebugOrchestrator(
       var (debuggerFileName, debuggerArguments) = DebuggerLocator.GetLaunchCommand(debuggerEngine, binaryPath);
       var applyValueConverters = debuggerEngine != DebuggerEngine.SharpDbg && (clientService?.ClientOptions?.DebuggerOptions?.ApplyValueConverters ?? false);
       var memCpuUsage = clientService?.ClientOptions?.DebuggerOptions?.MemCpuUsage ?? false;
+      var automaticSourceFileMap = await GetAutomaticSourceFileMapAsync(cancellationToken);
 
       var session = debugSessionFactory.Create(
           async (dapRequest, proxy) =>
@@ -167,7 +174,8 @@ public class DebugOrchestrator(
           },
           applyValueConverters,
           memCpuUsage,
-          variableLocationResolver);
+          variableLocationResolver,
+          automaticSourceFileMap);
 
       _sessionServices[sessionKey] = session;
 
@@ -289,6 +297,36 @@ public class DebugOrchestrator(
     catch (Exception ex)
     {
       logger.LogError(ex, "Failed to stop debug session {SessionKey} after start timeout.", sessionKey);
+    }
+  }
+
+  private async Task<IReadOnlyDictionary<string, string>> GetAutomaticSourceFileMapAsync(
+      CancellationToken cancellationToken)
+  {
+    using var mappingWaitCancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+    mappingWaitCancellation.CancelAfter(_automaticSourceFileMapWaitTimeout);
+
+    try
+    {
+      var snapshot = await projectGraphService.WaitForCurrentLoadAsync(mappingWaitCancellation.Token);
+      return sourcePathMapProvider.GetMappings(snapshot);
+    }
+    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+    {
+      throw;
+    }
+    catch (OperationCanceledException exception)
+    {
+      logger.LogWarning(
+          exception,
+          "Project graph did not become available for automatic source path mapping within {Timeout}; continuing without it",
+          _automaticSourceFileMapWaitTimeout);
+      return new Dictionary<string, string>();
+    }
+    catch (Exception exception)
+    {
+      logger.LogWarning(exception, "Automatic source path mapping is unavailable; continuing without it");
+      return new Dictionary<string, string>();
     }
   }
 

--- a/docs/debugging/flow.md
+++ b/docs/debugging/flow.md
@@ -15,6 +15,18 @@ There are **two debugging flows**:
 
 Both flows ultimately result in the debugger listening on a TCP socket which the client connects to (typically via nvim-dap).
 
+## DAP source path mapping
+
+For solution-backed local sessions, the server automatically evaluates each project's MSBuild `PathMap` property while loading the project graph. A C# `PathMap` contains comma-separated `physicalPath=sourcePath` entries, with literal commas and equals signs escaped by doubling them. The server reverses each valid entry into a debugger/PDB prefix to local physical prefix mapping and configures the debugger proxy before DAP traffic starts.
+
+Only successfully evaluated projects contribute mappings. Duplicate mappings are collapsed, identity mappings are omitted, and malformed or conflicting entries are logged and skipped. A debugger prefix mapped to different physical roots is omitted entirely because it is ambiguous. Project evaluation and automatic mapping are best-effort: a missing solution, a project graph still loading after the bounded mapping wait, failed project evaluation, or invalid `PathMap` does not prevent debugging, while successful projects still provide a partial map.
+
+The evaluated MSBuild value is authoritative, including values expanded from imported props and project-level overrides. Because the easy-dotnet server runs locally, the physical side of `PathMap` is already a valid Neovim path; no client option is required.
+
+Automatic mappings reflect the current project-graph snapshot. Reload or reinitialize the solution after changing build properties such as `PathMap` to refresh the mapping baseline.
+
+The proxy uses these automatic mappings in both directions. It maps client paths back to debugger/PDB paths in source-bearing requests and maps debugger paths to local paths in responses and events, so the selected debugger does not need native path-mapping support.
+
 # 1. Client-Initiated Debugging Session
 
 In this flow, the client directly calls the server’s debugger/start endpoint.


### PR DESCRIPTION
## Problem

Solution-backed projects can use MSBuild's `PathMap` property to replace physical source paths in portable PDBs with deterministic or repository-relative paths.

The editor still sends the local physical path when setting a breakpoint. For example, the PDB may contain:

```text
EasyDotnet.PathMapRepro/Program.cs
```

while the DAP client sends:

```text
<repo>/Program.cs
```

NetCoreDbg cannot match these paths, leaving the breakpoint pending and unverified.

Deriving mappings in the server avoids duplicating build configuration in the client. It also uses the evaluated MSBuild value, including imported props, property expansion, and project-level overrides.

## Reproduction

Public minimal reproduction: https://github.com/Robinfr/easy-dotnet-pathmap-repro

Set a breakpoint at `Program.cs:27` using unmodified upstream `easy-dotnet.nvim` and NetCoreDbg, with no client-side `sourceFileMap` mappings.

| EasyDotnet server | Path sent to NetCoreDbg | Result |
| --- | --- | --- |
| 3.4.20 | Absolute `<repo>/Program.cs` | Pending/unverified |
| This branch | `EasyDotnet.PathMapRepro/Program.cs` | Verified |

The client supplied zero source-path mappings in both cases.

## Solution

This change adds a shared bidirectional DAP source-path mapper and derives its mappings automatically from each project's evaluated MSBuild `PathMap`.

The BuildServer now exposes the evaluated `PathMap` property. Its property-cache schema is incremented to invalidate entries created before that property was collected.

Project graph loading makes the evaluated project snapshot available to `DebugOrchestrator`. A debug session waits up to five seconds for the current graph; timeout or evaluation failure falls back to an empty map rather than preventing the debugger from starting.

C# `PathMap` entries use the following direction:

```text
physical-path=debugger-path
```

The server reverses these into debugger-to-local mappings. Parsing follows Roslyn's doubled-comma and doubled-equals escaping rules.

Mapping discovery:

- Omits identity mappings.
- Collapses exact duplicate mappings.
- Conservatively omits connected overlapping or conflicting prefix regions rather than risking a path being mapped to the wrong checkout.
- Skips malformed entries and logs the reason.
- Retains valid disjoint mappings from successfully evaluated projects.

The proxy then:

- Rewrites source-bearing client requests from local paths to PDB/debugger paths.
- Rewrites debugger responses and events back to local paths.
- Preserves unknown debug-adapter fields while rewriting recognized source structures.
- Leaves sessions without applicable mappings unchanged.

No `easy-dotnet.nvim` changes or client-side source-path configuration are required.

## Current limitations

- Automatic discovery currently applies to solution-backed workspaces.
- The project graph is evaluated with the default `Debug` configuration and no explicit platform. Configuration-, platform-, or target-framework-specific `PathMap` values are not selected from the exact binary being debugged.
- Changes to `PathMap` require the EasyDotnet workspace/server to be reinitialized before they are reflected in a new debug session.

## Testing

- `EasyDotnet.Debugger.Tests`: 48 passed
- `EasyDotnet.IDE.Tests`: 111 passed
- `EasyDotnet.BuildServer.SmokeTests`: 27 passed
- `dotnet format EasyDotnet.slnx --verify-no-changes --no-restore`: passed
- `git diff --check`: passed
- Public reproduction with server 3.4.20: breakpoint remained pending
- Public reproduction with this rebased branch: breakpoint at `Program.cs:27` verified with zero client mappings

The affected projects build with zero warnings and errors. A full local solution build remains blocked by the existing unavailable `Microsoft.CodeAnalysis.ExternalAccess.Extensions` dependency in `EasyDotnet.RoslynLanguageServices`.
